### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/z-shell/zpmod/security/code-scanning/12](https://github.com/z-shell/zpmod/security/code-scanning/12)

To fix the issue, we need to explicitly define the permissions for the workflow. Since the workflow performs basic CI tasks like checking out code and running shell scripts, it only requires `contents: read` permissions. We will add a `permissions` block at the root level of the workflow to apply these permissions to all jobs. This ensures that the `GITHUB_TOKEN` has the least privileges necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
