### PR TITLE
workflows consistently

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read    
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: ☑️ ShellCheck
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
         with:
@@ -34,7 +34,7 @@ jobs:
     needs: [shellcheck]
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: ⚙️ Prepare
         run: |
           sudo apt-get update

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: ☑️ ShellCheck
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
         with:
@@ -31,7 +31,7 @@ jobs:
     needs: [shellcheck]
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: ⚙️ Determine Branch
         id: branch
         env:


### PR DESCRIPTION
This pull request updates the version of the `actions/checkout` GitHub Action used in both the Linux and macOS test workflow files. The change ensures that the workflows consistently use the newer commit reference for checking out code during CI runs.

Updates to GitHub Actions workflow configuration:

* [`.github/workflows/test-linux.yml`](diffhunk://#diff-fb0daef94ea304514bcccf51bdd0e30a073788e28fce22a7303d91203c69db70L23-R23): Changed the `actions/checkout` version to use commit `08c6903cd8c0fde910a37f88322edcfb5dd907a8` in both the initial checkout and the build steps. [[1]](diffhunk://#diff-fb0daef94ea304514bcccf51bdd0e30a073788e28fce22a7303d91203c69db70L23-R23) [[2]](diffhunk://#diff-fb0daef94ea304514bcccf51bdd0e30a073788e28fce22a7303d91203c69db70L37-R37)
* [`.github/workflows/test-macos.yml`](diffhunk://#diff-60e66ca8b630611c89b474be16a0c987928cfce83f77968025815c302ad731feL22-R22): Updated the `actions/checkout` version to the same newer commit in both the initial checkout and the build steps. [[1]](diffhunk://#diff-60e66ca8b630611c89b474be16a0c987928cfce83f77968025815c302ad731feL22-R22) [[2]](diffhunk://#diff-60e66ca8b630611c89b474be16a0c987928cfce83f77968025815c302ad731feL34-R34)