### PR TITLE
fix: skip ZWC compilation for non-regular sources

### DIFF
--- a/Src/zi/zpmod.c
+++ b/Src/zi/zpmod.c
@@ -886,6 +886,7 @@ Eprog custom_try_source_file(char *file)
 	}
 	/* If there is no zwc file, or if it is less recent than script file */
 	if ((!rn && (rc || (stc.st_mtime < stn.st_mtime))) &&
+            S_ISREG(stn.st_mode) &&
 	    (access(file_dup, W_OK) == 0 || 0 == strcmp(
 						     getsparam("ZI_MOD_DEBUG") ? getsparam("ZI_MOD_DEBUG") : "0",
 						     "1")))

--- a/Test/V12zpmod.ztst
+++ b/Test/V12zpmod.ztst
@@ -1,0 +1,20 @@
+# Tests for sourcing files through the zi/zpmod module.
+
+%prep
+  module_path=( $ZTST_testdir/../Src $module_path )
+  if ! zmodload zi/zpmod 2>/dev/null; then
+    ZTST_unimplemented="can't load the zi/zpmod module for testing"
+  fi
+  mkdir zpmod.tmp
+
+%test
+  unset nonregular_source_result
+  () {
+    [[ ! -f "$1" ]] || return 1
+    ln -s "$1" zpmod.tmp/nonregular-source
+    source zpmod.tmp/nonregular-source
+  } <(print -r -- 'typeset -g nonregular_source_result=executed')
+  print -r -- "${nonregular_source_result:-missing}"
+  [[ ! -e zpmod.tmp/nonregular-source.zwc ]]
+0:Sourcing a non-regular process substitution without compiling it
+>executed


### PR DESCRIPTION
## Summary

- gate automatic ZWC compilation on a successful regular-file check
- source process substitution through the existing file-descriptor fallback
- verify the content executes without a ZWC warning or `.zwc` artifact

## Testing

- `make -C Src/zi zpmod.so`
- `cd Test && zsh +Z -f ./ztst.zsh ./V12zpmod.ztst`

Fixes #31.
Tracked in #70.