### PR TITLE
ci: verify standalone and Zi-managed builds

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,66 +1,138 @@
 ---
-name: 🐧 Build (Linux)
+name: Linux CI
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch: {}
+  workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  shellcheck:
+  lint-scripts:
+    name: Lint scripts on Linux
     runs-on: ubuntu-latest
-    permissions:
-      contents: read    
+    timeout-minutes: 10
     steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - name: ☑️ ShellCheck
-        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
+      - name: Check out repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          scandir: "./Scripts/install.sh"
+          fetch-depth: 1
+          persist-credentials: false
 
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    timeout-minutes: 30
-    needs: [shellcheck]
-    steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - name: ⚙️ Prepare
+      - name: Install lint dependencies
         run: |
+          set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y zsh
-      - name: ⚙️ Determine Branch
-        id: branch
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-          REF_NAME: ${{ github.ref_name }}
-          EVENT_NAME: ${{ github.event_name }}
+          sudo apt-get install --yes --no-install-recommends shellcheck zsh
+
+      - name: Lint shell scripts
         run: |
-          # For PR events, use HEAD_REF; for push events, use REF_NAME
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            echo "branch=$HEAD_REF" >> $GITHUB_OUTPUT
-          else
-            echo "branch=$REF_NAME" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          shellcheck Scripts/install.sh
+          sh -n Scripts/install.sh
+          for file in Scripts/*.zsh Test/*.zsh; do
+            zsh -n "$file"
+            zsh -fc 'zcompile -R -- "$1" "$2"' _ \
+              "$RUNNER_TEMP/$(basename "$file").zwc" "$file"
+          done
+
+  standalone-build:
+    name: Build standalone module on Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends build-essential zsh
+
+      - name: Build standalone module
+        run: |
+          set -euo pipefail
+          source_dir="$(mktemp -d "$RUNNER_TEMP/zpmod-standalone.XXXXXX")"
+          git archive HEAD | tar -x -C "$source_dir"
+          sh "$source_dir/Scripts/install.sh" \
+            --no-git \
+            --target="$source_dir" \
+            --build-only \
+            --jobs=2
+          printf 'ZPMOD_MODULE_DIR=%s\n' "$source_dir/Src" >> "$GITHUB_ENV"
+
+      - name: Test standalone module
+        run: |
+          set -euo pipefail
+          zsh Test/ci-module.zsh "$ZPMOD_MODULE_DIR"
+
+  zi-managed-build:
+    name: Build Zi-managed module on Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends build-essential zsh
+
+      - name: Prepare latest Zi
+        run: |
+          set -euo pipefail
+          zi_test_home="$(mktemp -d "$RUNNER_TEMP/zi-managed.XXXXXX")"
+          zi_root="$zi_test_home/.zi"
+          candidate_remote="$zi_test_home/zpmod-candidate.git"
+
+          git clone --depth 1 https://github.com/z-shell/zi.git "$zi_root/bin"
+          printf 'Using Zi %s from its default branch\n' \
+            "$(git -C "$zi_root/bin" rev-parse HEAD)"
+
+          git init --bare --quiet "$candidate_remote"
+          git push --quiet "$candidate_remote" HEAD:refs/heads/ci-candidate
+          git --git-dir="$candidate_remote" symbolic-ref \
+            HEAD refs/heads/ci-candidate
+          mkdir -p "$zi_root/zmodules"
+          git clone --quiet "$candidate_remote" "$zi_root/zmodules/zpmod"
+
+          printf 'ZI_TEST_HOME=%s\n' "$zi_test_home" >> "$GITHUB_ENV"
+          printf 'ZPMOD_EXPECTED_REVISION=%s\n' \
+            "$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Build module through Zi
+        run: |
+          set -euo pipefail
+          HOME="$ZI_TEST_HOME" zsh -f -c '
+            source "$HOME/.zi/bin/zi.zsh"
+            zi module build
+          '
+
+      - name: Test Zi-managed module
+        run: |
+          set -euo pipefail
+          module_root="$ZI_TEST_HOME/.zi/zmodules/zpmod"
+          actual_revision="$(git -C "$module_root" rev-parse HEAD)"
+          if [[ "$actual_revision" != "$ZPMOD_EXPECTED_REVISION" ]]; then
+            printf 'Zi built revision %s instead of %s\n' \
+              "$actual_revision" "$ZPMOD_EXPECTED_REVISION" >&2
+            exit 1
           fi
-      - name: ⚙️ Build
-        env:
-          BRANCH_NAME: ${{ steps.branch.outputs.branch }}
-        run: |
-          sh ./Scripts/install.sh --no-git --target=$(pwd) --branch="$BRANCH_NAME"
-          ls -la ./Src/zi
-      - name: ⚙️ Load
-        run: |
-          module_path+=( "$PWD/Src" )
-          zmodload zi/zpmod
-          zpmod source-study -l
-        shell: zsh {0}
+          zsh Test/ci-module.zsh "$module_root/Src"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install build dependencies

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Prepare latest Zi

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -1,5 +1,6 @@
 ---
-name: 🍎 Build (MacOS)
+name: macOS CI
+
 on:
   push:
     branches: [main]
@@ -11,54 +12,87 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  shellcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - name: ☑️ ShellCheck
-        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
-        with:
-          scandir: "./Scripts/install.sh"
-
-  build:
+  standalone-build:
+    name: Build standalone module on macOS
     runs-on: macos-latest
     timeout-minutes: 30
-    needs: [shellcheck]
     steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - name: ⚙️ Determine Branch
-        id: branch
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-          REF_NAME: ${{ github.ref_name }}
-          EVENT_NAME: ${{ github.event_name }}
+      - name: Check out repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Build standalone module
         run: |
-          # For PR events, use HEAD_REF; for push events, use REF_NAME
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            echo "branch=$HEAD_REF" >> $GITHUB_OUTPUT
-          else
-            echo "branch=$REF_NAME" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          source_dir="$(mktemp -d "$RUNNER_TEMP/zpmod-standalone.XXXXXX")"
+          git archive HEAD | tar -x -C "$source_dir"
+          sh "$source_dir/Scripts/install.sh" \
+            --no-git \
+            --target="$source_dir" \
+            --build-only \
+            --jobs=2
+          printf 'ZPMOD_MODULE_DIR=%s\n' "$source_dir/Src" >> "$GITHUB_ENV"
+
+      - name: Test standalone module
+        run: |
+          set -euo pipefail
+          zsh Test/ci-module.zsh "$ZPMOD_MODULE_DIR"
+
+  zi-managed-build:
+    name: Build Zi-managed module on macOS
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Prepare latest Zi
+        run: |
+          set -euo pipefail
+          zi_test_home="$(mktemp -d "$RUNNER_TEMP/zi-managed.XXXXXX")"
+          zi_root="$zi_test_home/.zi"
+          candidate_remote="$zi_test_home/zpmod-candidate.git"
+
+          git clone --depth 1 https://github.com/z-shell/zi.git "$zi_root/bin"
+          printf 'Using Zi %s from its default branch\n' \
+            "$(git -C "$zi_root/bin" rev-parse HEAD)"
+
+          git init --bare --quiet "$candidate_remote"
+          git push --quiet "$candidate_remote" HEAD:refs/heads/ci-candidate
+          git --git-dir="$candidate_remote" symbolic-ref \
+            HEAD refs/heads/ci-candidate
+          mkdir -p "$zi_root/zmodules"
+          git clone --quiet "$candidate_remote" "$zi_root/zmodules/zpmod"
+
+          printf 'ZI_TEST_HOME=%s\n' "$zi_test_home" >> "$GITHUB_ENV"
+          printf 'ZPMOD_EXPECTED_REVISION=%s\n' \
+            "$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Build module through Zi
+        run: |
+          set -euo pipefail
+          HOME="$ZI_TEST_HOME" zsh -f -c '
+            source "$HOME/.zi/bin/zi.zsh"
+            zi module build
+          '
+
+      - name: Test Zi-managed module
+        run: |
+          set -euo pipefail
+          module_root="$ZI_TEST_HOME/.zi/zmodules/zpmod"
+          actual_revision="$(git -C "$module_root" rev-parse HEAD)"
+          if [[ "$actual_revision" != "$ZPMOD_EXPECTED_REVISION" ]]; then
+            printf 'Zi built revision %s instead of %s\n' \
+              "$actual_revision" "$ZPMOD_EXPECTED_REVISION" >&2
+            exit 1
           fi
-      - name: ⚙️ Prepare
-        run: |
-          brew install zsh
-      - name: ⚙️ Build
-        env:
-          BRANCH_NAME: ${{ steps.branch.outputs.branch }}
-        run: |
-          # Use --no-git to prevent cloning and use the checked out code
-          # Use --target to build in the current directory
-          sh ./Scripts/install.sh --no-git --target=$(pwd) --branch="$BRANCH_NAME"
-          ls -la ./Src/zi
-      - name: ⚙️ Load
-        run: |
-          module_path+=( "$PWD/Src" )
-          zmodload zi/zpmod
-          zpmod source-study -l
-        shell: zsh {0}
+          zsh Test/ci-module.zsh "$module_root/Src"

--- a/Test/ci-module.zsh
+++ b/Test/ci-module.zsh
@@ -1,0 +1,64 @@
+#!/usr/bin/env zsh
+
+emulate -LR zsh
+setopt err_exit no_unset pipe_fail
+
+if (( $# != 1 )); then
+  print -u2 "Usage: ${0:t} MODULE_DIR"
+  exit 2
+fi
+
+typeset -r module_dir=${1:A}
+if [[ ! -d $module_dir ]]; then
+  print -u2 "Module directory does not exist: $module_dir"
+  exit 1
+fi
+
+typeset temp_dir
+temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/zpmod-ci.XXXXXX")
+trap 'rm -rf -- "$temp_dir"' EXIT
+
+module_path=( "$module_dir" "${module_path[@]}" )
+zmodload zi/zpmod
+
+if (( ! ${+builtins[zpmod]} )); then
+  print -u2 "The zpmod builtin was not registered"
+  exit 1
+fi
+
+typeset usage
+usage=$(zpmod -h)
+if [[ $usage != *"zpmod source-study"* ]]; then
+  print -u2 "The zpmod help output is incomplete"
+  exit 1
+fi
+
+typeset -gA ZI_REPORTS
+ZI_REPORTS[ci/module]=""
+zpmod report-append ci/module first
+zpmod report-append ci/module second
+if [[ ${ZI_REPORTS[ci/module]} != firstsecond ]]; then
+  print -u2 "The report-append command returned unexpected data"
+  exit 1
+fi
+
+typeset -r fixture=$temp_dir/fixture.zsh
+print -r -- 'typeset -g ZPMOD_CI_FIXTURE=loaded' > "$fixture"
+source "$fixture"
+
+if [[ ${ZPMOD_CI_FIXTURE:-} != loaded ]]; then
+  print -u2 "The module did not source the fixture"
+  exit 1
+fi
+
+if [[ ! -s $fixture.zwc ]]; then
+  print -u2 "The module did not compile the sourced fixture"
+  exit 1
+fi
+
+typeset source_report
+source_report=$(zpmod source-study -l)
+if [[ $source_report != *"$fixture"* ]]; then
+  print -u2 "The source-study report did not include the fixture"
+  exit 1
+fi


### PR DESCRIPTION
## Why

The existing workflows only proved that zpmod could compile and load from the checkout. They did not exercise the supported Zi-managed installation path or assert meaningful module behavior.

## What changed

- Split Linux and macOS coverage into stable, separately diagnosable standalone and Zi-managed jobs.
- Exercise the real `zi module build` command using Zi's latest default branch while ensuring Zi builds the exact candidate zpmod revision.
- Add a shared clean-temp behavioral test covering module loading, builtin registration, help output, report appends, automatic `.zwc` compilation, and source-study reporting.
- Add explicit read-only permissions, cancellation concurrency, bounded timeouts, robust shells, and non-persistent checkout credentials.
- Keep the base branch's checkout v5 pin so PR #68 remains the owner of checkout dependency updates.

## Validation

- `git diff --check`
- YAML parsing for both workflows
- `sh -n Scripts/install.sh`
- `zsh -n` and `zcompile` for all `Scripts/*.zsh` and `Test/*.zsh`
- Clean standalone build and behavioral test on macOS with Zsh 5.9
- Actual Zi-managed build and behavioral test using Zi default-branch revision `4147d13573a2bbac466e62d44beb3b87ba8b0254`

Linux runtime validation could not be reproduced locally because Docker was unavailable; GitHub CI is the remaining Linux runtime proof.

Related to #70