### PR TITLE
feat: support staged system installation

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -219,3 +219,25 @@ jobs:
             exit 1
           fi
           zsh Test/ci-module.zsh "$module_root/Src"
+
+  system-install:
+    name: Test staged system install on Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends build-essential zsh
+
+      - name: Test staged system installation
+        run: |
+          set -euo pipefail
+          zsh Test/ci-system-install.zsh

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -98,3 +98,19 @@ jobs:
             exit 1
           fi
           zsh Test/ci-module.zsh "$module_root/Src"
+
+  system-install:
+    name: Test staged system install on macOS
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Test staged system installation
+        run: |
+          set -euo pipefail
+          zsh Test/ci-system-install.zsh

--- a/Makefile.in
+++ b/Makefile.in
@@ -48,6 +48,16 @@ all: config.h config.modules
 prep:
 	@cd Src && $(MAKE) $(MAKEDEFS) $@
 
+# ========== DEPENDENCIES FOR INSTALLING ==========
+
+install: install.modules
+uninstall: uninstall.modules
+.PHONY: install uninstall
+
+install.modules uninstall.modules:
+	@cd Src && $(MAKE) $(MAKEDEFS) $@
+.PHONY: install.modules uninstall.modules
+
 # ========== DEPENDENCIES FOR CLEANUP ==========
 
 @CLEAN_MK@

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ make DESTDIR="$pkgdir" MODDIR="$zsh_module_dir" uninstall
 packaging root without changing installed paths; `MODDIR` selects the exact Zsh
 module directory. Package recipes should set `MODDIR` explicitly because the
 bundled build metadata cannot infer the target distribution's Zsh layout,
-especially for cross builds.
+especially for cross builds. Cross-build recipes should use the target
+distribution's known module path instead of querying the build host's Zsh.
 
 Do not use `Scripts/install.sh` or `build.sh` in package builds. Those are
 interactive convenience entry points and can clone or update a checkout unless

--- a/README.md
+++ b/README.md
@@ -13,27 +13,65 @@ The module is a binary Zsh module (think about `zmodload` Zsh command, it's that
 
 ### Without [Zi](https://github.com/z-shell/zi)
 
-#### Quick Install (Recommended)
+#### Traditional system or package installation
 
-Install just the **standalone** binary which can be used with any other plugin manager.
-
-> **Note**
-> This script can be used with most plugin managers and [Zi](https://github.com/z-shell/zi) is not required.
+The traditional build is the recommended path for system administrators and
+package maintainers. It does not clone, update, or download anything during the
+build:
 
 ```sh
-sh <(curl -fsSL https://raw.githubusercontent.com/z-shell/zpmod/main/Scripts/install.sh)
+./configure --prefix=/usr \
+  --enable-cflags="-g -Wall -Wextra -O3" \
+  --disable-gdbm \
+  --without-tcsetpgrp
+make
 ```
 
-This script will display what to add to `~/.zshrc` (2 lines) and show usage instructions.
+Zsh modules are versioned and may use a distribution-specific or multiarch
+directory. Resolve the target using the Zsh that will load `zpmod`:
 
-#### Manual Install with Advanced Options
+```sh
+zsh_module_dir=$(zsh -fc 'print -r -- $module_path[1]')
+```
 
-You can also clone the repository and use the included build.sh script with various configuration options:
+For a direct system installation:
+
+```sh
+sudo make MODDIR="$zsh_module_dir" install
+```
+
+For a package build, stage files with `DESTDIR`:
+
+```sh
+pkgdir=$PWD/pkg
+make DESTDIR="$pkgdir" MODDIR="$zsh_module_dir" install
+```
+
+This installs one namespaced module at
+`$MODDIR/zi/zpmod.<platform-extension>`. Use the same variables to remove it:
+
+```sh
+make DESTDIR="$pkgdir" MODDIR="$zsh_module_dir" uninstall
+```
+
+`--prefix` controls Autotools defaults such as `libdir`; `DESTDIR` adds a
+packaging root without changing installed paths; `MODDIR` selects the exact Zsh
+module directory. Package recipes should set `MODDIR` explicitly because the
+bundled build metadata cannot infer the target distribution's Zsh layout,
+especially for cross builds.
+
+Do not use `Scripts/install.sh` or `build.sh` in package builds. Those are
+interactive convenience entry points and can clone or update a checkout unless
+`--no-git` is supplied.
+
+#### Convenience build
+
+For an interactive per-user build, clone the repository and run `build.sh`:
 
 ```sh
 git clone https://github.com/z-shell/zpmod.git
 cd zpmod
-./build.sh [OPTIONS]
+./build.sh --no-git
 ```
 
 The build script supports these options:
@@ -51,7 +89,7 @@ The build script supports these options:
 | `--branch=NAME`                | Use specific git branch (default: main)                           |
 | `--zsh-path=PATH`              | Use specific Zsh executable                                       |
 | `--jobs=N`, `-jN`              | Set number of parallel make jobs                                  |
-| `--prefix=DIR`                 | Set installation prefix (for system installs)                     |
+| `--prefix=DIR`                 | Set convenience target root (`DIR/share/zsh/zpmod`)               |
 | `--no-install`                 | Skip installation after building                                  |
 | `--help`, `-h`                 | Show help message                                                 |
 
@@ -64,14 +102,8 @@ The build script supports these options:
 # Build with specific compiler optimizations
 ./build.sh --cflags="-O3 -march=native"
 
-# System installation
-sudo ./build.sh --prefix=/usr/local
-
 # Quiet installation with 8 parallel jobs
 ./build.sh --quiet --jobs=8
-
-# Development build from a specific branch
-./build.sh --branch=develop --verbose
 ```
 
 ### With [Zi](https://github.com/z-shell/zi)
@@ -87,21 +119,33 @@ This command will compile the module and display instructions on what to add to 
 
 ## Loading the Module
 
-After installation, add these lines at the top of your `~/.zshrc`:
+After a traditional installation, ensure the selected module directory is in
+`module_path`, then load and verify the module:
 
 ```zsh
-# Adjust the path if you installed to a custom location
+module_path+=( /usr/lib/zsh/5.9 ) # Use your resolved $zsh_module_dir.
+zmodload zi/zpmod
+(( ${+builtins[zpmod]} ))
+zpmod -h
+```
+
+The convenience build prints its module directory. Its default can be loaded
+with:
+
+```zsh
 module_path+=( "${HOME}/.zi/zmodules/zpmod/Src" )
 zmodload zi/zpmod
 ```
 
 ## Measuring Time of Sources
 
-Besides the compilation-feature, the module also measures **duration** of each script sourcing.
-Issue `zpmod source-study` after loading the module at top of `~/.zshrc` to see a list of all sourced files with the time the
-sourcing took in milliseconds on the left.
-This feature allows you to profile the shell startup. Also, no script can pass through that check and you will obtain a complete list of all loaded scripts,
-like if Zshell itself was investigating this. The list can be surprising.
+Besides compilation, the module measures the **duration** of each sourced
+script. Compiled files are written as adjacent `*.zwc` files when the source is
+a writable regular file.
+
+Run `zpmod source-study` after loading the module near the top of `~/.zshrc` to
+list sourced files and their load times in milliseconds. This report is a
+timing profile, not an indication that every listed source was compiled.
 
 ## Debugging
 

--- a/Src/Makefile.in
+++ b/Src/Makefile.in
@@ -159,6 +159,7 @@ mostlyclean-modules clean-modules distclean-modules realclean-modules:
 
 # ========== RECURSIVE MAKES ==========
 
+install.modules uninstall.modules \
 modobjs modules headers proto zsh.export: Makemod
 	@$(MAKE) -f Makemod $(MAKEDEFS) $@
-.PHONY: headers proto
+.PHONY: install.modules uninstall.modules headers proto

--- a/Test/ci-system-install.zsh
+++ b/Test/ci-system-install.zsh
@@ -1,0 +1,73 @@
+#!/usr/bin/env zsh
+
+emulate -LR zsh
+setopt err_exit no_unset pipe_fail
+
+typeset -r repo_root=${0:A:h:h}
+typeset temp_dir
+temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/zpmod-system-install.XXXXXX")
+trap 'rm -rf -- "$temp_dir"' EXIT
+
+typeset -r source_dir=$temp_dir/source
+typeset -r stage_dir=$temp_dir/stage
+typeset -r shim_dir=$temp_dir/shims
+mkdir -p "$source_dir" "$stage_dir" "$shim_dir"
+
+git -C "$repo_root" archive HEAD | tar -x -C "$source_dir"
+
+for command_name in git curl; do
+  cat > "$shim_dir/$command_name" <<EOF
+#!/bin/sh
+echo "unexpected $command_name invocation during package build" >&2
+exit 97
+EOF
+  chmod +x "$shim_dir/$command_name"
+done
+
+typeset -r build_path=$shim_dir:$PATH
+typeset -r module_dir=$(zsh -fc 'print -r -- $module_path[1]')
+
+(
+  cd "$source_dir"
+  PATH=$build_path ./configure \
+    --prefix=/usr \
+    --enable-cflags="-g -Wall -Wextra -O3" \
+    --disable-gdbm \
+    --without-tcsetpgrp \
+    --quiet
+  PATH=$build_path make --jobs=2
+  PATH=$build_path make \
+    DESTDIR="$stage_dir" \
+    MODDIR="$module_dir" \
+    install
+)
+
+typeset -r dl_ext=$(
+  sed -n 's/^DL_EXT[[:space:]]*=[[:space:]]*//p' \
+    "$source_dir/Config/defs.mk"
+)
+typeset -r installed_module=$stage_dir$module_dir/zi/zpmod.$dl_ext
+typeset -a installed_files
+installed_files=( "$stage_dir"/**/*(.N) )
+
+if (( ${#installed_files} != 1 )) ||
+   [[ ${installed_files[1]:-} != $installed_module ]]; then
+  print -u2 "Unexpected staged files:"
+  print -u2 -l -- "${installed_files[@]}"
+  exit 1
+fi
+
+zsh "$source_dir/Test/ci-module.zsh" "$stage_dir$module_dir"
+
+(
+  cd "$source_dir"
+  PATH=$build_path make \
+    DESTDIR="$stage_dir" \
+    MODDIR="$module_dir" \
+    uninstall
+)
+
+if [[ -e $installed_module ]]; then
+  print -u2 "Uninstall left the module in place: $installed_module"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- expose the existing Autotools `install.modules` and `uninstall.modules` targets through the root and `Src` makefiles
- support package-manager staging with explicit `DESTDIR` and target-specific `MODDIR` while preserving the `zi/zpmod` module namespace
- document an offline traditional build/install path that does not invoke the network-capable convenience installer
- add a clean-tree regression that blocks `git` and `curl`, stages exactly one namespaced module, verifies module behavior, and verifies uninstall
- run the staged install/uninstall regression as distinct Linux and macOS CI jobs

## Package contract

Package recipes configure and build normally, resolve or supply the target Zsh module directory, then run:

```sh
make DESTDIR="$pkgdir" MODDIR="$zsh_module_dir" install
```

Cross builds must provide the target distribution's known module path instead of querying the build host's Zsh.

## Validation

- `trunk check --no-fix --filter=markdownlint,prettier README.md`
- `trunk check --no-fix --filter=actionlint,prettier` on both workflows
- `zsh -n` and `zcompile -R` for `Test/ci-system-install.zsh`
- `zsh Test/ci-system-install.zsh` on macOS
- clean exported-tree configure/build with failing `git` and `curl` shims
- exact staged `zi/zpmod.so` assertion and existing behavioral fixture
- staged uninstall assertion
- whitespace check with Makefile recipe tabs excluded from `tab-in-indent`

References #28.
Part of #70.