### PR TITLE
fix: guard uninitialized report hash

### DIFF
--- a/src/builtins/zpmod_builtin.c
+++ b/src/builtins/zpmod_builtin.c
@@ -60,6 +60,10 @@ static int zp_append_report(const char *nam /* reporting name */,
     return 1;
   }
   HashTable ht = pm->u.hash;
+  if (!ht) {
+    zwarnnam(nam, "%sunknown plugin: %s", zp_icon("❌ "), target);
+    return 1;
+  }
   HashNode hn = gethashnode2(ht, target);
   Param val_pm = (Param)hn;
   if (!val_pm) {

--- a/tests/command/zpmod_report_append.zsh
+++ b/tests/command/zpmod_report_append.zsh
@@ -9,7 +9,20 @@ TEST_NAME="command/zpmod_report_append"
 load_zpmod
 
 typeset -gA ZI_REPORTS
+
+# A declared associative parameter has no hash table until it is initialized.
+# report-append must reject that state without dereferencing a null table.
+if zpmod report-append z-shell/not-registered '+first'; then
+  print -u2 -- 'report-append accepted an uninitialized ZI_REPORTS hash'
+  exit 1
+fi
+
 ZI_REPORTS=()
+
+# An explicit empty entry is valid and must be appendable.
+ZI_REPORTS['z-shell/empty']=''
+zpmod report-append z-shell/empty '+one'
+[[ ${ZI_REPORTS['z-shell/empty']} == '+one' ]]
 
 # Seed
 ZI_REPORTS["z-shell/zbrowse"]='seed'


### PR DESCRIPTION
Closes #80

## Summary

- reject a declared but uninitialized `ZI_REPORTS` hash before dereferencing its table
- cover the declared-only state and an explicit empty entry

## Verification

- `ctest --test-dir build --output-on-failure` (37/37 passed)
- targeted pre-fix regression test: segfault reproduced