### PR TITLE
refactor(builtins): rename readarray to zpreadarray before release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ add_library(zpmod MODULE
   src/core/bundle_build.c
   src/builtins/zpmod_builtin.c
   src/builtins/fs_builtins.c
-  src/builtins/readarray.c
+  src/builtins/zpreadarray.c
   src/compat/options.c
 )
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -17,7 +17,7 @@ The codebase is split into clear layers:
 - `src/builtins/` — thin wrappers that expose functionality as builtins
   - `zpmod_builtin.c`: the `zpmod` command (subcommands: report-append, source-study, dir-list, path-stat, read-file)
   - `fs_builtins.c`: `zppathstat`, `zpdirlist`, `zpreadfile`
-  - `readarray.c`: `readarray` builtin
+  - `zpreadarray.c`: `zpreadarray` builtin
 - `src/compat/` — cross-version shims
   - `options.c`: stable-to-runtime option mapping for varying zsh versions
 - `src/include/` — public headers wiring modules together

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -8,6 +8,6 @@ Task‑oriented guides for common zpmod scenarios.
 - [Force a rebuild](force-rebuild.md)
 - [Profile shell startup](profile-startup.md)
 - [Enable debug logging](enable-debug.md)
-- [Use readarray builtin](use-readarray.md)
+- [Use zpreadarray builtin](use-zpreadarray.md)
 - [Append to plugin report](append-report.md)
 - [Build documentation with containers](build-docs-container.md)

--- a/docs/how-to/use-zpreadarray.md
+++ b/docs/how-to/use-zpreadarray.md
@@ -1,11 +1,11 @@
-# Use the readarray Builtin
+# Use the zpreadarray Builtin
 
-zpmod provides a `readarray` builtin (bash-like) to read records into an indexed array.
+zpmod provides a `zpreadarray` builtin to read records into an indexed array.
 
 Basic usage:
 
 ```zsh
-print -r -- $'a\nb\nc' | readarray A
+print -r -- $'a\nb\nc' | zpreadarray A
 print -r -- ${#A[@]}  # => 3
 ```
 
@@ -26,17 +26,17 @@ Examples:
 
 ```zsh
 # Custom delimiter, keep delimiters
-print -nr -- 'x,y,z,' | readarray -d , B
+print -nr -- 'x,y,z,' | zpreadarray -d , B
 print -r -- ${B[@]}   # 'x,' 'y,' 'z,' ''
 
 # Custom delimiter, trim (-t)
-print -nr -- 'x,y,z,' | readarray -t -d , B
+print -nr -- 'x,y,z,' | zpreadarray -t -d , B
 print -r -- ${B[@]}   # x y z ''
 
 # Start at index 5
 B=(1 2 3 4)
-print -r -- $'a\nb' | readarray -O 5 B
+print -r -- $'a\nb' | zpreadarray -O 5 B
 # B -> (1 2 3 4 a b)
 ```
 
-See full details in [Reference › Builtins](../reference/builtins.md#readarray).
+See full details in [Reference > Builtins](../reference/builtins.md#zpreadarray).

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -34,17 +34,17 @@ Return codes:
 - 0 success
 - 1 usage / parameter errors
 
-## readarray
+## zpreadarray
 
-Bash-like record reader into indexed arrays.
+Record reader into indexed arrays.
 
 Synopsis:
 
 ```zsh
-readarray [-d delim] [-n count] [-O origin] [-s count] [-t] [-u fd] [-C callback] [-c quantum] array
+zpreadarray [-d delim] [-n count] [-O origin] [-s count] [-t] [-u fd] [-C callback] [-c quantum] array
 ```
 
-See: [How-to › Use readarray](../how-to/use-readarray.md)
+See: [How-to > Use zpreadarray](../how-to/use-zpreadarray.md)
 
 ## zppathstat
 

--- a/src/README.md
+++ b/src/README.md
@@ -3,7 +3,7 @@
 This directory contains the zpmod module sources organized by layer:
 
 - core: cross-cutting logic and overrides (e.g., `source.c`, `fs.c`, `utils.c`, `emoji.c`)
-- builtins: builtin entrypoints (e.g., `zpmod_builtin.c`, `readarray.c`, `fs_builtins.c`)
+- builtins: builtin entrypoints (e.g., `zpmod_builtin.c`, `zpreadarray.c`, `fs_builtins.c`)
 - compat: compatibility shims and stable mappings across zsh versions (e.g., `options.c`, `sigcount.h`)
 - include: public cross-unit headers (`zpmod_*.h`) — do not include internal zsh headers here
 - module: zsh module glue (static builtin table in `module.c`, `zpmod.mdh/.pro` stubs and imports)

--- a/src/builtins/zpreadarray.c
+++ b/src/builtins/zpreadarray.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 /**
- * @file readarray.c
- * @brief readarray builtin: read records from stdin or fd into an array.
+ * @file zpreadarray.c
+ * @brief zpreadarray builtin: read records from stdin or fd into an array.
  */
 /* Canonical module header ordering */
 #include "zpmod.mdh"
@@ -13,17 +13,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static void readarray_usage(void) {
+static void zpreadarray_usage(void) {
   fprintf(stdout,
-          "%sUsage:%s readarray [-d delim] [-n count] [-O origin] [-s count] "
+          "%sUsage:%s zpreadarray [-d delim] [-n count] [-O origin] [-s count] "
           "[-t] [-u fd] [-C callback] [-c quantum] array\n"
           "Read records from standard input (or -u fd) into the named array.\n",
           zp_icon("📥 "), "");
   fflush(stdout);
 }
 
-/** readarray builtin entrypoint */
-int bin_readarray(char *nam, char **argv, Options ops, int func) {
+/** zpreadarray builtin entrypoint */
+int bin_zpreadarray(char *nam, char **argv, Options ops, int func) {
   (void)func; /* unused */
   int srcfd = 0;
   char *callback = NULL;

--- a/src/include/zpmod_builtins.h
+++ b/src/include/zpmod_builtins.h
@@ -7,7 +7,7 @@ struct builtin;
 struct builtin *zp_get_self_builtins(size_t *count);
 struct builtin *zp_get_fs_builtins(size_t *count);
 
-/* Other builtins implemented as direct handlers (readarray, custom_dot) */
-int bin_readarray(char *nam, char **argv, Options ops, int func);
+/* Other builtins implemented as direct handlers (zpreadarray, custom_dot) */
+int bin_zpreadarray(char *nam, char **argv, Options ops, int func);
 int bin_custom_dot(char *name, char **argv, Options ops, int func);
 int bin_zpmod(char *nam, char **argv, Options ops, int func);

--- a/src/module/module.c
+++ b/src/module/module.c
@@ -19,7 +19,7 @@ static struct builtin bintab[] = {
 #ifdef ZPMOD_HAVE_SOURCE_STUDY
     BUILTIN("custom_dot", 0, bin_custom_dot, 1, -1, 0, NULL, NULL),
 #endif
-    BUILTIN("readarray", 0, bin_readarray, 1, 1, 0, "d:n:O:s:tu:C:c:h", NULL),
+    BUILTIN("zpreadarray", 0, bin_zpreadarray, 1, 1, 0, "d:n:O:s:tu:C:c:h", NULL),
     BUILTIN("zppathstat", 0, bin_zppathstat, 2, 2, 0, "Lf:", NULL),
     BUILTIN("zpdirlist", 0, bin_zpdirlist, 2, 2, 0, "adf", NULL),
     BUILTIN("zpreadfile", 0, bin_zpreadfile, 2, 2, 0, "md:0", NULL),

--- a/src/module/zpmod.pro
+++ b/src/module/zpmod.pro
@@ -13,8 +13,8 @@
 
 /* Builtin handlers */
 int bin_custom_dot(char *name, char **argv, Options ops, int func);
-/* readarray builtin (implemented in builtins/readarray.c) */
-int bin_readarray(char *nam, char **argv, Options ops, int func);
+/* zpreadarray builtin (implemented in builtins/zpreadarray.c) */
+int bin_zpreadarray(char *nam, char **argv, Options ops, int func);
 
 /* zpmod command */
 void zpmod_usage(void);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,24 +89,24 @@ add_zpmod_test(zpmod_custom_dot builtin/custom_dot.zsh
 add_zpmod_test(zpmod_source_study core/source_study.zsh
   CATEGORY "core" LABELS "source-study")
 
-# readarray builtin tests
-add_zpmod_test(zpmod_readarray builtin/readarray.zsh
-  CATEGORY "builtin" LABELS "readarray;comprehensive")
+# zpreadarray builtin tests
+add_zpmod_test(zpmod_zpreadarray builtin/zpreadarray.zsh
+  CATEGORY "builtin" LABELS "zpreadarray;comprehensive")
 
-add_zpmod_test(zpmod_readarray_delim builtin/readarray_delim.zsh
-  CATEGORY "builtin" LABELS "readarray;edge_cases")
+add_zpmod_test(zpmod_zpreadarray_delim builtin/zpreadarray_delim.zsh
+  CATEGORY "builtin" LABELS "zpreadarray;edge_cases")
 
-add_zpmod_test(zpmod_readarray_fd builtin/readarray_fd.zsh
-  CATEGORY "builtin" LABELS "readarray;file_descriptor")
+add_zpmod_test(zpmod_zpreadarray_fd builtin/zpreadarray_fd.zsh
+  CATEGORY "builtin" LABELS "zpreadarray;file_descriptor")
 
-add_zpmod_test(zpmod_readarray_clear builtin/readarray_clear.zsh
-  CATEGORY "builtin" LABELS "readarray;behavior")
+add_zpmod_test(zpmod_zpreadarray_clear builtin/zpreadarray_clear.zsh
+  CATEGORY "builtin" LABELS "zpreadarray;behavior")
 
-add_zpmod_test(zpmod_readarray_large builtin/readarray_large.zsh
-  CATEGORY "builtin" LABELS "readarray;stress" SLOW)
+add_zpmod_test(zpmod_zpreadarray_large builtin/zpreadarray_large.zsh
+  CATEGORY "builtin" LABELS "zpreadarray;stress" SLOW)
 
-add_zpmod_test(zpmod_readarray_fd_t builtin/readarray_fd_t.zsh
-  CATEGORY "builtin" LABELS "readarray;file_descriptor;trim")
+add_zpmod_test(zpmod_zpreadarray_fd_t builtin/zpreadarray_fd_t.zsh
+  CATEGORY "builtin" LABELS "zpreadarray;file_descriptor;trim")
 
 # zpmod command and subcommand tests
 add_zpmod_test(zpmod_report_append command/zpmod_report_append.zsh

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,7 +23,7 @@ All tests are under `tests/`:
 
 ### Naming
 
-- Descriptive names: `readarray.zsh`, `zpdirlist.zsh`, etc.
+- Descriptive names: `zpreadarray.zsh`, `zpdirlist.zsh`, etc.
 - Lowercase with underscores
 - `.zsh` extension
 - Shebang: `#!/usr/bin/env zsh`
@@ -31,7 +31,7 @@ All tests are under `tests/`:
 ### Categories
 
 - `core/` — Smoke and core availability
-- `builtin/` — Builtins like readarray, custom_dot
+- `builtin/` — Builtins like zpreadarray, custom_dot
 - `command/` — `zpmod` CLI and subcommands
 - `filesystem/` — Directory listing and path stat helpers
 - `file_io/` — File reading and parsing
@@ -140,7 +140,7 @@ ctest --test-dir build-cmake -R zpmod_my_new_test --output-on-failure
 zsh tests/core/smoke.zsh
 
 # With debug output
-ZPMOD_TEST_DEBUG=1 zsh tests/builtin/readarray.zsh
+ZPMOD_TEST_DEBUG=1 zsh tests/builtin/zpreadarray.zsh
 ```
 
 ### All tests via CMake/CTest

--- a/tests/builtin/zpreadarray.zsh
+++ b/tests/builtin/zpreadarray.zsh
@@ -1,5 +1,5 @@
 #!/usr/bin/env zsh
-# Validate readarray builtin provided by zpmod
+# Validate zpreadarray builtin provided by zpmod
 set -euo pipefail
 emulate -L zsh
 
@@ -7,53 +7,53 @@ emulate -L zsh
 source "${0:A:h:h}/test_helpers.zsh"
 
 # Set test name for reporting
-TEST_NAME="builtin/readarray"
+TEST_NAME="builtin/zpreadarray"
 
 # Load module
 load_zpmod
 
 # Test description
-test_info "Running readarray tests - verifying all readarray functionality"
+test_info "Running zpreadarray tests - verifying all zpreadarray functionality"
 
 # Test 1: Basic newline-delimited into array A
 test_debug "Testing basic newline-delimited input"
 A=()
-print -r -- $'a\nb\nc' | readarray A
+print -r -- $'a\nb\nc' | zpreadarray A
 (( ${#A[@]} == 3 ))
 [[ $A[1] == a && $A[2] == b && $A[3] == c ]]
 
 # Test 2: Custom delimiter: comma
 test_debug "Testing custom delimiter (comma)"
 B=()
-print -r -- 'x,y,z' | readarray -d , B
+print -r -- 'x,y,z' | zpreadarray -d , B
 (( ${#B[@]} == 3 ))
 [[ $B[1] == x && $B[2] == y && $B[3] == z ]]
 
 # Test 3: -n count: only first 2 items
 test_debug "Testing count limitation with -n option"
 C=()
-print -r -- $'1\n2\n3' | readarray -n 2 C
+print -r -- $'1\n2\n3' | zpreadarray -n 2 C
 (( ${#C[@]} == 2 ))
 [[ $C[1] == 1 && $C[2] == 2 ]]
 
 # Test 4: -O origin: append starting at index 4 (zsh arrays 1-based)
 test_debug "Testing origin offset with -O option"
 D=(a b c)
-print -r -- $'d\ne' | readarray -O 4 D
+print -r -- $'d\ne' | zpreadarray -O 4 D
 (( ${#D[@]} == 5 ))
 [[ $D[4] == d && $D[5] == e ]]
 
 # Test 5: -s skip: skip first item
 test_debug "Testing skip lines with -s option"
 E=()
-print -r -- $'skip\nkeep1\nkeep2' | readarray -s 1 E
+print -r -- $'skip\nkeep1\nkeep2' | zpreadarray -s 1 E
 (( ${#E[@]} == 2 ))
 [[ $E[1] == keep1 && $E[2] == keep2 ]]
 
 # Test 6: -t: strip delimiters; combining with comma delimiter
 test_debug "Testing strip delimiters with -t option"
 F=()
-print -r -- 'p,q,' | readarray -t -d , F
+print -r -- 'p,q,' | zpreadarray -t -d , F
 (( ${#F[@]} == 3 ))
 [[ $F[1] == p && $F[2] == q && $F[3] == '' ]]
 
@@ -62,7 +62,7 @@ test_debug "Testing file descriptor input with -u option"
 G=()
 {
 	exec {fd}<> <(print -r -- $'u1\nu2')
-	readarray -u $fd G
+	zpreadarray -u $fd G
 	exec {fd}>&-
 }
 (( ${#G[@]} == 2 ))
@@ -70,4 +70,4 @@ G=()
 
 # Test passed
 test_status "PASS" "$TEST_NAME"
-test_info "readarray functionality test completed successfully"
+test_info "zpreadarray functionality test completed successfully"

--- a/tests/builtin/zpreadarray_clear.zsh
+++ b/tests/builtin/zpreadarray_clear.zsh
@@ -1,15 +1,15 @@
 #!/usr/bin/env zsh
-# verify readarray clears the array when -O is not provided
+# verify zpreadarray clears the array when -O is not provided
 set -euo pipefail
 emulate -L zsh
 
 source "${0:A:h:h}/test_helpers.zsh"
-TEST_NAME="builtin/readarray_clear"
+TEST_NAME="builtin/zpreadarray_clear"
 load_zpmod
 
 ARR=(x y z)
 print -r -- $'a
-b' | readarray ARR
+b' | zpreadarray ARR
 (( ${#ARR[@]} == 2 ))
 [[ $ARR[1] == a && $ARR[2] == b ]]
 
@@ -19,10 +19,10 @@ b' | readarray ARR
 # With -O, previous elements before origin remain, and array is not cleared
 ARR=(1 2 3 4)
 print -r -- $'e
-f' | readarray -O 5 ARR
+f' | zpreadarray -O 5 ARR
 (( ${#ARR[@]} == 6 ))
 [[ $ARR[1] == 1 && $ARR[2] == 2 && $ARR[3] == 3 && $ARR[4] == 4 && $ARR[5] == e && $ARR[6] == f ]]
 
-print -r -- "readarray_clear OK"
+print -r -- "zpreadarray_clear OK"
 
 test_status "PASS" "$TEST_NAME"

--- a/tests/builtin/zpreadarray_delim.zsh
+++ b/tests/builtin/zpreadarray_delim.zsh
@@ -1,36 +1,36 @@
 #!/usr/bin/env zsh
-# Extra delimiter edge cases for readarray
+# Extra delimiter edge cases for zpreadarray
 set -euo pipefail
 emulate -L zsh
 
 source "${0:A:h:h}/test_helpers.zsh"
-TEST_NAME="builtin/readarray_delim"
+TEST_NAME="builtin/zpreadarray_delim"
 load_zpmod
 
 # Trailing record without delimiter
 X=()
-print -nr -- 'a,b' | readarray -d , X
+print -nr -- 'a,b' | zpreadarray -d , X
 (( ${#X[@]} == 2 ))
 [[ $X[1] == a && $X[2] == b ]]
 
 # Keep delimiter (-t off)
 Y=()
-print -nr -- 'p,q,' | readarray -d , Y
+print -nr -- 'p,q,' | zpreadarray -d , Y
 (( ${#Y[@]} == 3 ))
 [[ $Y[1] == 'p,' && $Y[2] == 'q,' && $Y[3] == '' ]]
 
 # Remove delimiter (-t)
 Z=()
-print -nr -- 'm,n,' | readarray -t -d , Z
+print -nr -- 'm,n,' | zpreadarray -t -d , Z
 (( ${#Z[@]} == 3 ))
 [[ $Z[1] == m && $Z[2] == n && $Z[3] == '' ]]
 
 # Skip with custom delimiter
 S=()
-print -nr -- 's1;s2;s3' | readarray -s 1 -d ';' S
+print -nr -- 's1;s2;s3' | zpreadarray -s 1 -d ';' S
 (( ${#S[@]} == 2 ))
 [[ $S[1] == s2 && $S[2] == s3 ]]
 
-print -r -- "readarray_delim OK"
+print -r -- "zpreadarray_delim OK"
 
 test_status "PASS" "$TEST_NAME"

--- a/tests/builtin/zpreadarray_fd.zsh
+++ b/tests/builtin/zpreadarray_fd.zsh
@@ -1,21 +1,21 @@
 #!/usr/bin/env zsh
-# readarray from fd with custom delimiter
+# zpreadarray from fd with custom delimiter
 set -euo pipefail
 emulate -L zsh
 
 source "${0:A:h:h}/test_helpers.zsh"
-TEST_NAME="builtin/readarray_fd"
+TEST_NAME="builtin/zpreadarray_fd"
 load_zpmod
 
 H=()
 {
 	exec {fd}<> <(print -nr -- 'aa;bb;cc;')
-	readarray -d ';' -u $fd H
+	zpreadarray -d ';' -u $fd H
 	exec {fd}>&-
 }
 (( ${#H[@]} == 4 ))
 [[ $H[1] == 'aa;' && $H[2] == 'bb;' && $H[3] == 'cc;' && $H[4] == '' ]]
 
-print -r -- "readarray_fd OK"
+print -r -- "zpreadarray_fd OK"
 
 test_status "PASS" "$TEST_NAME"

--- a/tests/builtin/zpreadarray_fd_t.zsh
+++ b/tests/builtin/zpreadarray_fd_t.zsh
@@ -1,16 +1,16 @@
 #!/usr/bin/env zsh
-# readarray from fd with custom delimiter and trimming (-t)
+# zpreadarray from fd with custom delimiter and trimming (-t)
 set -euo pipefail
 emulate -L zsh
 
 source "${0:A:h:h}/test_helpers.zsh"
-TEST_NAME="builtin/readarray_fd_t"
+TEST_NAME="builtin/zpreadarray_fd_t"
 load_zpmod
 
 ARR=()
 {
 	exec {fd}<> <(print -nr -- 'A;B;C;')
-	readarray -t -d ';' -u $fd ARR
+	zpreadarray -t -d ';' -u $fd ARR
 	exec {fd}>&-
 }
 
@@ -18,6 +18,6 @@ ARR=()
 (( ${#ARR[@]} == 4 ))
 [[ $ARR[1] == 'A' && $ARR[2] == 'B' && $ARR[3] == 'C' && $ARR[4] == '' ]]
 
-print -r -- "readarray_fd_t OK"
+print -r -- "zpreadarray_fd_t OK"
 
 test_status "PASS" "$TEST_NAME"

--- a/tests/builtin/zpreadarray_large.zsh
+++ b/tests/builtin/zpreadarray_large.zsh
@@ -4,7 +4,7 @@ set -euo pipefail
 emulate -L zsh
 
 source "${0:A:h:h}/test_helpers.zsh"
-TEST_NAME="builtin/readarray_large"
+TEST_NAME="builtin/zpreadarray_large"
 load_zpmod
 
 N=20000
@@ -21,11 +21,11 @@ trap 'rm -f -- $TMPFILE' EXIT
 
 ARR=()
 # Callback every 5000 to ensure no pathological slowdown
-readarray -C : -c 5000 -u {fd} ARR {fd}< $TMPFILE
+zpreadarray -C : -c 5000 -u {fd} ARR {fd}< $TMPFILE
 
 (( ${#ARR[@]} == N ))
 [[ $ARR[1] == r1 && $ARR[$N] == r$N ]]
 
-print -r -- "readarray_large OK"
+print -r -- "zpreadarray_large OK"
 
 test_status "PASS" "$TEST_NAME"


### PR DESCRIPTION
Closes #81

## Summary

- Rename unprefixed `readarray` builtin to `zpreadarray` across C entrypoints and module definitions
- Update prototypes in `zpmod_builtins.h` and `zpmod.pro`
- Update CMake build definitions and test targets in `CMakeLists.txt` and `tests/CMakeLists.txt`
- Rename and update test scripts in `tests/builtin/zpreadarray*.zsh`
- Update how-to, reference, and architecture documentation

## Verification

- `cmake --build build-cmake` compiled cleanly
- CTest suite executed with 100% pass rate (37/37 tests passed)