### PR TITLE
docs: restore root README and LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,37 @@
+Unless otherwise noted in the header of specific files, files in this
+distribution have the licence shown below.
+
+However, note that certain shell functions are licensed under versions
+of the GNU General Public Licence.  Anyone distributing the shell as a
+binary including those files needs to take account of this.  Search
+shell functions for "Copyright" for specific copyright information.
+None of the core functions are affected by this, so those files may
+simply be omitted.
+
+--
+
+The Z Shell is copyright (c) 1992-2017 Paul Falstad, Richard Coleman,
+Zoltán Hidvégi, Andrew Main, Peter Stephenson, Sven Wischnowsky, and
+others.  All rights reserved.  Individual authors, whether or not
+specifically named, retain copyright in all changes; in what follows, they
+are referred to as `the Zsh Development Group'.  This is for convenience
+only and this body has no legal status.  The Z shell is distributed under
+the following licence; any provisions made in individual files take
+precedence.
+
+Permission is hereby granted, without written agreement and without
+licence or royalty fees, to use, copy, modify, and distribute this
+software and to distribute modified versions of this software for any
+purpose, provided that the above copyright notice and the following
+two paragraphs appear in all copies of this software.
+
+In no event shall the Zsh Development Group be liable to any party for
+direct, indirect, special, incidental, or consequential damages arising out
+of the use of this software and its documentation, even if the Zsh
+Development Group have been advised of the possibility of such damage.
+
+The Zsh Development Group specifically disclaim any warranties, including,
+but not limited to, the implied warranties of merchantability and fitness
+for a particular purpose.  The software provided hereunder is on an "as is"
+basis, and the Zsh Development Group have no obligation to provide
+maintenance, support, updates, enhancements, or modifications.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# zpmod
+
+⚙️ Zsh module that transparently and automatically compiles sourced scripts.
+
+`zpmod` is a binary Zsh module (`zmodload`) that gives any Zsh setup automatic `.zwc` compilation of sourced scripts, including setups whose
+plugin manager does not compile plugins itself (and setups that don't use a plugin manager at all).
+
+## Quick start
+
+```zsh
+# Add to the top of ~/.zshrc
+module_path+=("${HOME}/.zi/zmodules/zpmod")
+zmodload -i zpmod
+
+# After the shell starts, profile sourced scripts
+zpmod source-study
+```
+
+## Installation
+
+- Traditional system or package install (no `zi`, no network access during the build): see
+  [docs/how-to/system-install.md](docs/how-to/system-install.md).
+- Install with the CMake helper (`zi`, user, or system scope): see
+  [docs/how-to/install-zpmod-with-cmake.md](docs/how-to/install-zpmod-with-cmake.md).
+- Install to a custom directory: see [docs/how-to/install-custom-dir.md](docs/how-to/install-custom-dir.md).
+
+## Documentation
+
+Full documentation lives under [docs/](docs/index.md), organized as tutorials, how-to guides, reference, and explanation.
+
+## Contributing
+
+See [docs/explanation/contributing.md](docs/explanation/contributing.md).
+
+## License
+
+`zpmod` is distributed under the Zsh license; see [LICENSE](LICENSE). It builds against and vendors Zsh itself (`vendor/zsh`), copyright (c)
+the Zsh Development Group; see that submodule for its own licensing terms.


### PR DESCRIPTION
## Summary

- restore a root `LICENSE` (unmodified Zsh license text, preserving upstream notices) and a root `README.md`, both GitHub-detectable
- rewrite `README.md` for the current CMake-based layout (quick start, install paths, docs links, license note) instead of reusing the old Autotools-era copy

## Context

#71 restored the root `README.md`/`LICENSE` for this exact checklist item in #70. #61's later squash merge (2026-08-17) replaced the whole pre-CMake tree and silently dropped both files again — confirmed by diffing #61's merge commit against its parent, where `README.md` and `LICENSE` are among 133 files deleted. This restores them against the tree as it exists today, not the pre-#61 Autotools content (which described a build system that no longer exists).

## Validation

- `trunk check --no-fix --filter=markdownlint,prettier README.md` (clean after `trunk fmt`)

Refs #70