### PR TITLE
fix: skip ZWC compilation for non-regular sources

### DIFF
--- a/src/core/source.c
+++ b/src/core/source.c
@@ -355,7 +355,7 @@ Eprog custom_try_source_file(char *file) {
   if (faltered) {
     *tail++ = '/';
   }
-  if ((!rn && (rc || (stc.st_mtime < stn.st_mtime))) &&
+  if ((!rn && (rc || (stc.st_mtime < stn.st_mtime))) && S_ISREG(stn.st_mode) &&
       (access(file_dup, W_OK) == 0 || debug_enabled)) {
     char *args[] = {file, NULL};
     struct options ops;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,6 +85,10 @@ add_zpmod_test(zpmod_builtin_present core/builtin_present.zsh
 add_zpmod_test(zpmod_custom_dot builtin/custom_dot.zsh
   CATEGORY "builtin" LABELS "custom_dot")
 
+# Regression test for #31: process substitution must not be ZWC-compiled
+add_zpmod_test(zpmod_process_substitution_source builtin/process_substitution_source.zsh
+  CATEGORY "builtin" LABELS "custom_dot;regression")
+
 # Source-study formatting and options
 add_zpmod_test(zpmod_source_study core/source_study.zsh
   CATEGORY "core" LABELS "source-study")

--- a/tests/builtin/process_substitution_source.zsh
+++ b/tests/builtin/process_substitution_source.zsh
@@ -1,0 +1,44 @@
+#!/usr/bin/env zsh
+# Regression test for #31: sourcing a non-regular file (e.g. a process
+# substitution FIFO/fd path) must not attempt ZWC compilation.
+set -euo pipefail
+emulate -L zsh
+
+# Source helpers and set test name
+source "${0:A:h:h}/test_helpers.zsh"
+TEST_NAME="builtin/process_substitution_source"
+
+# Load module
+load_zpmod
+
+workdir=$(mktemp -d)
+trap 'rm -rf -- "$workdir"' EXIT
+
+# Source a process substitution's /proc/self/fd/N path directly: the
+# original #31 report. zpmod must not attempt to zcompile it (it can't be
+# written back to under /proc), and it must execute silently either way.
+unset nonregular_source_result
+source <(print -r -- 'typeset -g nonregular_source_result=executed') 2>"$workdir/stderr.log"
+nonregular_stderr=$(<"$workdir/stderr.log")
+
+assert_equal "${nonregular_source_result:-missing}" "executed" \
+  "Sourcing a process substitution should still execute its content"
+assert_empty "$nonregular_stderr" \
+  "Sourcing a process substitution must not warn about ZWC compilation"
+
+# Same guard via a symlinked non-regular source (fifo), so a stray .zwc
+# sibling landing in a normal, writable directory is easy to assert on too.
+() {
+  [[ ! -f "$1" ]] || return 1
+  ln -s "$1" "$workdir/nonregular-source"
+  source "$workdir/nonregular-source"
+} <(print -r -- 'typeset -g nonregular_source_result=executed')
+
+[[ ! -e "$workdir/nonregular-source.zwc" ]] ||
+  { print -ru2 -- "unexpected: nonregular-source.zwc was compiled"; exit 1 }
+
+print -r -- "process_substitution_source OK"
+
+# Report
+test_status "PASS" "$TEST_NAME"
+test_info "process_substitution_source test completed successfully"


### PR DESCRIPTION
## Summary

- gate automatic ZWC compilation in `custom_try_source_file` on `S_ISREG(stn.st_mode)`, mirroring #72's merged fix for #31 line-for-line
- add `tests/builtin/process_substitution_source.zsh`: sources a process substitution's literal `/proc/self/fd/N` path (the original report) and asserts no ZWC warning reaches stderr and no `.zwc` sibling is written; also covers a symlinked-fifo case

## Context

#31 ("can't write zwc file: /proc/self/fd/15.zwc") was fixed by #72 by adding this exact regular-file guard to the old `Src/zi/zpmod.c`. #61's later squash merge (2026-08-17) replaced the whole pre-CMake tree — including `Src/zi/zpmod.c` and `Test/V12zpmod.ztst` — and the guard never made it into the new `src/core/source.c`/`tests/` layout. `source <(...)` currently reprints the original error on `main`.

## Validation

Built `vendor/zsh`'s own `Src/zsh` locally (required — the module patches the running zsh's live `builtintab`, so it needs ABI parity with whatever zsh loads it; a system-packaged zsh of a different build silently no-ops the override) and confirmed:

- unfixed: `source <(print -r -- 'true')` prints `can't write zwc file: /proc/self/fd/N.zwc`; new test fails on that stderr output
- fixed: no warning, no stray `.zwc`; new test passes
- full `tests/builtin/*` and `tests/core/*` suites still pass

Refs #70