### PR TITLE
chore(release): exclude bot authors from auto-generated notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,31 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - dependabot[bot]
+      - renovate
+      - renovate[bot]
+      - copilot-swe-agent[bot]
+  categories:
+    - title: Features
+      labels:
+        - type:feature
+    - title: Fixes
+      labels:
+        - type:bug
+        - bug
+        - regression
+    - title: Documentation
+      labels:
+        - type:docs
+        - area:docs
+    - title: Maintenance
+      labels:
+        - type:maintenance
+        - chore
+        - refactor
+        - ci
+        - area:ci
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary

The \`v2.0.1\` release notes (generated via \`gh release create --generate-notes\` in the release workflow) pulled in three years of \`dependabot[bot]\` version-bump lines going back to 2023, e.g.:

> build(deps): bump actions/checkout from 3.2.0 to 3.3.0 by @dependabot[bot] in #2

Root cause: \`v2.0.0\` is a bare tag with no GitHub Release object, so GitHub's auto-anchor for "previous release" fell back to \`v1.1.0\` (Jan 2023), sweeping in every PR merged since then. Now that \`v2.0.1\` is a proper Release, the anchor should self-correct for the next tag, but nothing stops future Dependabot/Renovate PRs merged before the next tag from showing up again — there was no exclude config.

## Change

Add \`.github/release.yml\` (GitHub's autogenerated-notes config) to:

- Exclude \`dependabot[bot]\`, \`renovate[bot]\`, and \`copilot-swe-agent[bot]\` authored PRs from the changelog.
- Group the remaining entries into Features / Fixes / Documentation / Maintenance / Other Changes categories by label.

No workflow logic changes; this only affects how \`--generate-notes\` renders.

Part of #70.