### PR TITLE
fix(security): harden filesystem cache writes

### DIFF
--- a/src/core/compaudit_cache.c
+++ b/src/core/compaudit_cache.c
@@ -21,6 +21,7 @@
 /* System headers after gateway */
 #include "zpmod_compaudit.h"
 #include "zpmod_emoji.h"
+#include "zpmod_utils.h"
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -412,13 +413,12 @@ static int zp_cc_incremental_update(char *nam, char *cache_path,
   }
   int insecure = 0;
   int secure = 0;
-  FILE *fp = fopen(cache_path, "w");
+  FILE *fp = zp_fopen_write_nofollow(cache_path, 0600, 1);
   if (!fp) {
     zwarnnam(nam, "%scompaudit-cache: cannot update %s: %s", zp_icon("❌ "),
              cache_path, strerror(errno));
     return 1;
   }
-  fchmod(fileno(fp), 0600);
   fprintf(fp, "version:3\n");
   for (size_t i = 0; i < entries->size; i++) {
     struct stat st;
@@ -516,13 +516,12 @@ static int zp_cc_rebuild(char *nam, const char *file_path,
   uid_t self = geteuid();
   int insecure = 0;
   int secure = 0;
-  FILE *fp = fopen(file_path, "w");
+  FILE *fp = zp_fopen_write_nofollow(file_path, 0600, 1);
   if (!fp) {
     zwarnnam(nam, "%scompaudit-cache: cannot write %s: %s", zp_icon("❌ "),
              file_path, strerror(errno));
     return 1;
   }
-  fchmod(fileno(fp), 0600);
   fprintf(fp, "version:3\n");
   for (size_t i = 0; i < targets->size; i++) {
     struct stat st;
@@ -602,10 +601,12 @@ int zp_compaudit_cache_core(char *nam, int rebuild, int show, int json) {
         if (v2path) {
           memcpy(v2path, cache_path, prefix);
           strcpy(v2path + prefix, rep);
-          struct stat st_old;
-          if (stat(v2path, &st_old) == 0) {
+          if (unlink(v2path) == 0) {
             rebuild = 1;
-            unlink(v2path); /* best-effort removal */
+          } else if (errno != ENOENT) {
+            /* A legacy path exists but cannot be removed. Rebuild the current
+             * cache without a separate check/use window. */
+            rebuild = 1;
           }
           zsfree(v2path);
         }

--- a/src/core/fpath.c
+++ b/src/core/fpath.c
@@ -7,6 +7,7 @@
 #include "zpmod.mdh"
 #include "zpmod.pro"
 #include "zpmod_fpath.h"
+#include "zpmod_utils.h"
 #include "zpmod_vendor_shims.h"
 #include <dirent.h>
 #include <stdio.h>
@@ -239,7 +240,7 @@ int cmd_fpath_index(char *nam, char **argv) {
   /* Build / preload */
   FILE *out_fp = stdout;
   if (outfile) {
-    out_fp = fopen(outfile, "w");
+    out_fp = zp_fopen_write_nofollow(outfile, 0644, 0);
     if (!out_fp) {
       zwarnnam(nam, "cannot open for writing: %s", outfile);
       return 1;

--- a/src/core/rehash_diff.c
+++ b/src/core/rehash_diff.c
@@ -15,6 +15,7 @@
 #include "zpmod.pro"
 #include "zpmod_emoji.h"
 #include "zpmod_rehash.h"
+#include "zpmod_utils.h"
 #include "zpmod_vendor_shims.h"
 #include <errno.h>
 #include <stdio.h>
@@ -192,7 +193,7 @@ static int rh_load(const char *nam, const char *file, struct rh_vec *out) {
 // NOLINTEND(bugprone-easily-swappable-parameters)
 
 static int rh_write(char *nam, const char *file, struct rh_vec *paths) {
-  FILE *fp = fopen(file, "w");
+  FILE *fp = zp_fopen_write_nofollow(file, 0600, 1);
   if (!fp) {
     zwarnnam(nam, "%srehash-diff: cannot write %s: %s", zp_icon("❌ "), file,
              strerror(errno));

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -7,7 +7,66 @@
 #include "zpmod.pro"
 #include "zpmod_utils.h"
 #include "zpmod_vendor_shims.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+FILE *zp_fopen_write_nofollow(const char *path, mode_t create_mode,
+                              int enforce_mode) {
+#ifndef O_NOFOLLOW
+  (void)path;
+  (void)create_mode;
+  (void)enforce_mode;
+  errno = ENOTSUP;
+  return NULL;
+#else
+  int flags = O_WRONLY | O_CREAT;
+#ifdef O_CLOEXEC
+  flags |= O_CLOEXEC;
+#endif
+  flags |= O_NOFOLLOW;
+
+  int fd = open(path, flags, create_mode);
+  if (fd < 0) {
+    return NULL;
+  }
+
+#ifndef O_CLOEXEC
+  if (fcntl(fd, F_SETFD, FD_CLOEXEC) < 0) {
+    int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return NULL;
+  }
+#endif
+
+  if (enforce_mode && fchmod(fd, create_mode) < 0) {
+    int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return NULL;
+  }
+
+  if (ftruncate(fd, 0) < 0) {
+    int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return NULL;
+  }
+
+  FILE *stream = fdopen(fd, "w");
+  if (!stream) {
+    int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+  }
+  return stream;
+#endif
+}
 
 /** Lightweight argv short-option scanner (stops at "--"). */
 int zp_has_option(char **argv, char opt) {

--- a/src/include/zpmod_utils.h
+++ b/src/include/zpmod_utils.h
@@ -1,6 +1,9 @@
 /* SPDX-License-Identifier: MIT */
 #pragma once
 
+#include <stdio.h>
+#include <sys/types.h>
+
 /**
  * @file zpmod_utils.h
  * @brief Utility helpers shared across module components.
@@ -59,3 +62,19 @@ int zp_has_option(char **argv, char opt);
  *        -1 if the option matched but the argument was missing.
  */
 int zp_take_opt_with_arg(char ***argvp, char opt, char **out_arg);
+
+/**
+ * @brief Open a file for truncating writes without following symlinks.
+ *
+ * The file receives `create_mode` at creation time, independent of a permissive
+ * process umask. Existing file permissions are preserved unless
+ * `enforce_mode` is non-zero, in which case the opened descriptor is restricted
+ * to `create_mode` before a stream is returned.
+ *
+ * @param path         Output path.
+ * @param create_mode  Permissions used when creating the file.
+ * @param enforce_mode Whether to apply create_mode to an existing file too.
+ * @return Writable stream, or NULL with errno preserved on failure.
+ */
+FILE *zp_fopen_write_nofollow(const char *path, mode_t create_mode,
+                              int enforce_mode);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,9 @@ add_zpmod_test(zpmod_path_warmup_prune command/zpmod_path_warmup_prune.zsh
 add_zpmod_test(zpmod_fpath_index command/zpmod_fpath_index.zsh
   CATEGORY "command" LABELS "fpath;indexing")
 
+add_zpmod_test(zpmod_secure_files command/zpmod_secure_files.zsh
+  CATEGORY "command" LABELS "security;filesystem;regression")
+
 # Compat: options mapping sentinel and basics
 add_zpmod_test(zpmod_options_mapping compat/options_mapping.zsh
   CATEGORY "core" LABELS "compat;options;loader")

--- a/tests/command/zpmod_secure_files.zsh
+++ b/tests/command/zpmod_secure_files.zsh
@@ -1,0 +1,124 @@
+#!/usr/bin/env zsh
+# Security regression coverage for file creation and cache replacement.
+emulate -L zsh
+set -euo pipefail
+
+source "${0:A:h:h}/test_helpers.zsh"
+TEST_NAME="command/zpmod_secure_files"
+load_zpmod
+
+workdir=$(mktemp -d 2>/dev/null || mktemp -d -t zpmod-secure-files)
+trap 'rm -rf -- "$workdir"' EXIT
+
+fail_test() {
+  print -ru2 -- "$*"
+  exit 1
+}
+
+file_mode() {
+  command stat -c %a -- "$1" 2>/dev/null || command stat -f %Lp "$1"
+}
+
+assert_mode() {
+  local filepath=$1 expected=$2 actual
+  actual=$(file_mode "$filepath")
+  [[ $actual == $expected ]] ||
+    fail_test "unexpected mode for $filepath: got $actual, expected $expected"
+}
+
+assert_victim_unchanged() {
+  local victim_path=$1 expected=$2 operation=$3
+  if "$operation" >/dev/null 2>&1; then
+    fail_test "$operation followed a symlinked output"
+  fi
+  [[ $(<"$victim_path") == "$expected" ]] ||
+    fail_test "$operation modified the symlink target"
+}
+
+# Deliberately remove the process umask as a safety net. Creation modes must
+# still deny group/other writes.
+umask 000
+
+# fpath-index: public index data may be readable, but never group/other writable.
+fdir="$workdir/fpath"
+index="$workdir/fpath.index"
+mkdir -p "$fdir"
+print 'echo secure' >"$fdir/example"
+saved_fpath=( $fpath )
+fpath=( "$fdir" )
+zpmod fpath-index --out "$index" --rebuild || fail_test "fpath-index failed"
+assert_mode "$index" 644
+fpath=( $saved_fpath )
+
+# fpath-index must not follow a caller-supplied output symlink.
+fdir="$workdir/fpath-symlink"
+victim="$workdir/fpath-victim"
+output="$workdir/fpath-link"
+mkdir -p "$fdir"
+print 'echo secure' >"$fdir/example"
+print -r -- 'preserve-fpath-victim' >"$victim"
+ln -s "$victim" "$output"
+saved_fpath=( $fpath )
+fpath=( "$fdir" )
+_run_fpath_symlink() { zpmod fpath-index --out "$output" --rebuild }
+assert_victim_unchanged "$victim" 'preserve-fpath-victim' _run_fpath_symlink
+fpath=( $saved_fpath )
+
+# rehash-diff snapshots contain PATH data and are private regardless of umask.
+export XDG_CACHE_HOME="$workdir/rehash-cache"
+mkdir -p "$XDG_CACHE_HOME"
+zpmod rehash-diff >/dev/null || fail_test "rehash-diff failed"
+assert_mode "$XDG_CACHE_HOME/zpmod/rehash_path_v1.snapshot" 600
+
+# rehash-diff must not follow a cache-file symlink.
+export XDG_CACHE_HOME="$workdir/rehash-symlink-cache"
+mkdir -p "$XDG_CACHE_HOME/zpmod"
+victim="$workdir/rehash-victim"
+snapshot="$XDG_CACHE_HOME/zpmod/rehash_path_v1.snapshot"
+print -r -- 'preserve-rehash-victim' >"$victim"
+ln -s "$victim" "$snapshot"
+_run_rehash_symlink() { zpmod rehash-diff }
+assert_victim_unchanged "$victim" 'preserve-rehash-victim' _run_rehash_symlink
+
+# compaudit caches contain filesystem security metadata and are private.
+export XDG_CACHE_HOME="$workdir/compaudit-cache"
+mkdir -p "$XDG_CACHE_HOME"
+cdir="$workdir/compaudit-fpath"
+mkdir -p "$cdir"
+saved_fpath=( $fpath )
+fpath=( "$cdir" )
+zpmod compaudit-cache --rebuild >/dev/null || fail_test "compaudit rebuild failed"
+assert_mode "$XDG_CACHE_HOME/zpmod/compaudit_v3.zcache" 600
+fpath=( $saved_fpath )
+
+# compaudit-cache must not follow a cache-file symlink.
+export XDG_CACHE_HOME="$workdir/compaudit-symlink-cache"
+mkdir -p "$XDG_CACHE_HOME/zpmod"
+victim="$workdir/compaudit-victim"
+cache="$XDG_CACHE_HOME/zpmod/compaudit_v3.zcache"
+cdir="$workdir/compaudit-symlink-fpath"
+mkdir -p "$cdir"
+print -r -- 'preserve-compaudit-victim' >"$victim"
+ln -s "$victim" "$cache"
+saved_fpath=( $fpath )
+fpath=( "$cdir" )
+_run_compaudit_symlink() { zpmod compaudit-cache --rebuild }
+assert_victim_unchanged "$victim" 'preserve-compaudit-victim' _run_compaudit_symlink
+fpath=( $saved_fpath )
+
+# Migration removes the legacy path atomically even when it is a dangling
+# symlink. The symlink target must never be inspected or modified.
+export XDG_CACHE_HOME="$workdir/compaudit-migration-cache"
+mkdir -p "$XDG_CACHE_HOME/zpmod"
+legacy="$XDG_CACHE_HOME/zpmod/compaudit_v2.zcache"
+ln -s "$workdir/nonexistent-legacy-target" "$legacy"
+cdir="$workdir/compaudit-migration-fpath"
+mkdir -p "$cdir"
+saved_fpath=( $fpath )
+fpath=( "$cdir" )
+zpmod compaudit-cache --show >/dev/null || fail_test "compaudit migration failed"
+[[ ! -e "$legacy" && ! -L "$legacy" ]] ||
+  fail_test "dangling legacy cache path was not removed"
+fpath=( $saved_fpath )
+
+test_status "PASS" "$TEST_NAME"


### PR DESCRIPTION
## Summary

- create fpath indexes with non-writable public permissions and internal caches with enforced `0600` permissions
- centralize no-following, close-on-exec stream creation for all four CodeQL file-creation sites
- remove the legacy-cache `stat`/`unlink` check-use window by unlinking the path atomically
- add permissive-umask, symlink-target, and dangling-migration regression coverage

## Verification

- focused regression test failed against the pre-fix `fopen(..., "w")` implementation (`666` instead of `644`)
- migration regression failed against the pre-fix `stat`/`unlink` sequence
- `ctest --test-dir build-cmake --output-on-failure -j 2`: 47/47 passed
- `scripts/check_include_order.zsh`: passed
- `git diff --check`: passed

## Risk and compatibility

- caller-supplied `fpath-index --out` symlinks are now rejected instead of followed
- existing ordinary fpath-index file permissions are preserved; newly created indexes use at most `0644`
- internal rehash and compaudit caches are restricted to `0600`

Closes #93
