### PR TITLE
build(package): ship complete license notices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # Adopt standard install dir variables and centralize build output directories
 include(GNUInstallDirs)
+set(ZPMOD_DATA_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}" CACHE INTERNAL
+  "Effective architecture-independent data install directory" FORCE)
+set(ZPMOD_LICENSE_INSTALL_DIR "${ZPMOD_DATA_INSTALL_DIR}/licenses/zpmod")
+set(ZPMOD_DOC_INSTALL_DIR "${ZPMOD_DATA_INSTALL_DIR}/doc/zpmod")
 
 # Export compile_commands.json for clang-tidy/clangd and copy to source dir
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -66,6 +70,13 @@ string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" ZPMOD_VERSION_PATCH "
 # Generate version header
 set(GENERATED_DIR ${CMAKE_BINARY_DIR}/generated)
 file(MAKE_DIRECTORY ${GENERATED_DIR})
+file(READ "${CMAKE_SOURCE_DIR}/NOTICE" ZPMOD_NOTICE_TEXT)
+file(READ "${CMAKE_SOURCE_DIR}/LICENSES/MIT.txt" ZPMOD_MIT_LICENSE_TEXT)
+file(READ "${CMAKE_SOURCE_DIR}/LICENSE" ZPMOD_ZSH_LICENSE_TEXT)
+file(WRITE "${GENERATED_DIR}/copyright"
+  "${ZPMOD_NOTICE_TEXT}\n\nMIT license text\n----------------\n\n"
+  "${ZPMOD_MIT_LICENSE_TEXT}\n\nZsh license text\n----------------\n\n"
+  "${ZPMOD_ZSH_LICENSE_TEXT}\n")
 configure_file(
   ${CMAKE_SOURCE_DIR}/cmake/zpmod_version.h.in
   ${GENERATED_DIR}/zpmod_version.h
@@ -260,10 +271,26 @@ set(CPACK_DEBIAN_PACKAGE_DEPENDS "zsh")
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 
 # RPM package metadata
-set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+set(CPACK_RPM_PACKAGE_LICENSE "MIT AND LicenseRef-zsh")
 set(CPACK_RPM_PACKAGE_GROUP "Shells")
 set(CPACK_RPM_PACKAGE_REQUIRES "zsh")
 set(CPACK_RPM_FILE_NAME RPM-DEFAULT)
+# RPM packages are Linux artifacts and install below /usr even when CMake is
+# configured on another host for metadata validation.
+set(ZPMOD_RPM_INSTALL_PREFIX "/usr")
+if(IS_ABSOLUTE "${ZPMOD_LICENSE_INSTALL_DIR}")
+  set(ZPMOD_RPM_LICENSE_DIR "${ZPMOD_LICENSE_INSTALL_DIR}")
+else()
+  set(ZPMOD_RPM_LICENSE_DIR
+    "${ZPMOD_RPM_INSTALL_PREFIX}/${ZPMOD_LICENSE_INSTALL_DIR}")
+endif()
+string(REGEX REPLACE "/+" "/" ZPMOD_RPM_LICENSE_DIR
+  "${ZPMOD_RPM_LICENSE_DIR}")
+set(CPACK_RPM_USER_FILELIST
+  "%license ${ZPMOD_RPM_LICENSE_DIR}/LICENSE"
+  "%license ${ZPMOD_RPM_LICENSE_DIR}/LicenseRef-zsh.txt"
+  "%license ${ZPMOD_RPM_LICENSE_DIR}/MIT.txt"
+  "%license ${ZPMOD_RPM_LICENSE_DIR}/NOTICE")
 
 # macOS DMG (DragNDrop) needs no extra metadata
 
@@ -343,3 +370,22 @@ endif()
 install(FILES ${CMAKE_SOURCE_DIR}/src/completion/_zpmod
         DESTINATION ${CMAKE_INSTALL_DATADIR}/zsh/site-functions
         OPTIONAL)
+
+# Ship every license that applies to the installed binary/completion payload.
+install(FILES
+        ${CMAKE_SOURCE_DIR}/LICENSE
+        ${CMAKE_SOURCE_DIR}/NOTICE
+        DESTINATION ${ZPMOD_LICENSE_INSTALL_DIR}
+        COMPONENT Licenses)
+install(FILES ${CMAKE_SOURCE_DIR}/LICENSE
+        DESTINATION ${ZPMOD_LICENSE_INSTALL_DIR}
+        RENAME LicenseRef-zsh.txt
+        COMPONENT Licenses)
+install(FILES ${CMAKE_SOURCE_DIR}/LICENSES/MIT.txt
+        DESTINATION ${ZPMOD_LICENSE_INSTALL_DIR}
+        RENAME MIT.txt
+        COMPONENT Licenses)
+install(FILES ${GENERATED_DIR}/copyright
+        DESTINATION ${ZPMOD_DOC_INSTALL_DIR}
+        RENAME copyright
+        COMPONENT Licenses)

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) zpmod contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: MIT AND LicenseRef-zsh
+
+zpmod contains material under file-specific licenses:
+
+- Files carrying `SPDX-License-Identifier: MIT` are licensed under the MIT
+  License reproduced in `LICENSES/MIT.txt`.
+- Files without a more specific license notice are covered by the Zsh license
+  reproduced in the repository root `LICENSE` file, unless the file identifies
+  another license.
+- The `vendor/zsh` submodule remains copyright the Zsh Development Group and is
+  governed by its own included license. Its source tree is not installed into
+  zpmod binary packages.
+
+Copyright in each file remains with its respective contributors and upstream
+copyright holders. The license notices installed with binary packages describe
+the combined payload; they do not relicense any file or replace a file-specific
+notice.

--- a/README.md
+++ b/README.md
@@ -34,5 +34,6 @@ See [docs/explanation/contributing.md](docs/explanation/contributing.md).
 
 ## License
 
-`zpmod` is distributed under the Zsh license; see [LICENSE](LICENSE). It builds against and vendors Zsh itself (`vendor/zsh`), copyright (c)
-the Zsh Development Group; see that submodule for its own licensing terms.
+zpmod contains file-specific licensing. Project-owned module sources marked `SPDX-License-Identifier: MIT` use the
+[MIT license](LICENSES/MIT.txt); files without a more specific notice use the [Zsh license](LICENSE). See [NOTICE](NOTICE) for the
+package-level scope. The vendored Zsh source remains copyright the Zsh Development Group and retains its own licensing terms.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,14 @@ set_tests_properties(release_workflow_policy PROPERTIES
   TIMEOUT 20
   LABELS "ci;release;security")
 
+add_test(NAME package_license_payload
+  COMMAND ${ZSH_EXECUTABLE} -f ${CMAKE_CURRENT_SOURCE_DIR}/package/license_payload.zsh)
+set_tests_properties(package_license_payload PROPERTIES
+  ENVIRONMENT "ZPMOD_BUILD_DIR=${CMAKE_BINARY_DIR}"
+  FIXTURES_REQUIRED "StageReady"
+  TIMEOUT 30
+  LABELS "package;license;release")
+
 # Ensure the staged module exists before running any tests when invoking ctest directly.
 # We create a CTest fixture that builds the 'stage' target once and have tests require it.
 add_test(NAME stage_fixture

--- a/tests/package/license_payload.zsh
+++ b/tests/package/license_payload.zsh
@@ -1,0 +1,130 @@
+#!/usr/bin/env zsh
+# Verify that install/CPack payloads carry every applicable license notice.
+emulate -R zsh
+setopt err_exit no_unset pipe_fail
+
+source_root=${0:A:h:h:h}
+build_dir=${ZPMOD_BUILD_DIR:-$source_root/build-cmake}
+prefix=$(mktemp -d 2>/dev/null || mktemp -d -t zpmod-license-payload)
+trap 'rm -rf -- "$prefix"' EXIT
+
+fail_test() {
+  print -ru2 -- "$*"
+  exit 1
+}
+
+for source_notice in LICENSE NOTICE LICENSES/MIT.txt; do
+  [[ -f "$source_root/$source_notice" ]] ||
+    fail_test "missing source notice: $source_notice"
+done
+
+cmake --install "$build_dir" --prefix "$prefix" >/dev/null ||
+  fail_test 'staged install failed'
+
+install_data_dir=$(sed -n 's/^ZPMOD_DATA_INSTALL_DIR:INTERNAL=//p' \
+  "$build_dir/CMakeCache.txt")
+[[ -n $install_data_dir ]] || fail_test 'effective data install directory is unavailable'
+if [[ $install_data_dir == /* ]]; then
+  installed_data_root=$install_data_dir
+else
+  installed_data_root="$prefix/$install_data_dir"
+fi
+
+license_dir="$installed_data_root/licenses/zpmod"
+for installed_notice in LICENSE NOTICE MIT.txt LicenseRef-zsh.txt; do
+  [[ -s "$license_dir/$installed_notice" ]] ||
+    fail_test "missing installed notice: share/licenses/zpmod/$installed_notice"
+done
+[[ -s "$installed_data_root/doc/zpmod/copyright" ]] ||
+  fail_test 'missing Debian-style copyright notice'
+grep -q 'Permission is hereby granted' "$installed_data_root/doc/zpmod/copyright" ||
+  fail_test 'Debian-style copyright file omits the MIT terms'
+grep -q 'The Z Shell is copyright' "$installed_data_root/doc/zpmod/copyright" ||
+  fail_test 'Debian-style copyright file omits the Zsh terms'
+
+grep -q 'SPDX-License-Identifier: MIT AND LicenseRef-zsh' \
+  "$license_dir/NOTICE" ||
+  fail_test 'NOTICE lacks the package license expression'
+grep -q 'set(CPACK_RPM_PACKAGE_LICENSE "MIT AND LicenseRef-zsh")' \
+  "$build_dir/CPackConfig.cmake" ||
+  fail_test 'RPM metadata does not use the documented license expression'
+grep -q '%license /usr/share/licenses/zpmod/NOTICE' \
+  "$build_dir/CPackConfig.cmake" ||
+  fail_test 'RPM metadata does not mark the installed notices as licenses'
+
+# Inspect an actual generated archive rather than inferring CPack contents from
+# install rules alone.
+package_dir="$prefix/packages"
+mkdir -p "$package_dir"
+cpack --config "$build_dir/CPackConfig.cmake" -G TGZ -C Release \
+  -B "$package_dir" >/dev/null || fail_test 'TGZ generation failed'
+archives=( "$package_dir"/*.tar.gz(N) )
+(( ${#archives} == 1 )) || fail_test 'expected exactly one TGZ package'
+archive_listing=$(tar -tzf "$archives[1]")
+for packaged_notice in LICENSE NOTICE MIT.txt LicenseRef-zsh.txt; do
+  [[ $archive_listing == *"/share/licenses/zpmod/$packaged_notice"* ]] ||
+    fail_test "TGZ omits $packaged_notice"
+done
+[[ $archive_listing == *'/share/doc/zpmod/copyright'* ]] ||
+  fail_test 'TGZ omits the Debian-style copyright notice'
+
+if command -v dpkg-deb >/dev/null 2>&1; then
+  deb_dir="$prefix/deb-packages"
+  mkdir -p "$deb_dir"
+  cpack --config "$build_dir/CPackConfig.cmake" -G DEB -C Release \
+    -B "$deb_dir" >/dev/null || fail_test 'DEB generation failed'
+  debs=( "$deb_dir"/*.deb(N) )
+  (( ${#debs} == 1 )) || fail_test 'expected exactly one DEB package'
+  deb_listing=$(dpkg-deb --contents "$debs[1]")
+  [[ $deb_listing == *'/usr/share/doc/zpmod/copyright'* ]] ||
+    fail_test 'DEB omits /usr/share/doc/zpmod/copyright'
+  [[ $deb_listing == *'/usr/share/licenses/zpmod/MIT.txt'* ]] ||
+    fail_test 'DEB omits the MIT license text'
+fi
+
+if command -v rpmbuild >/dev/null 2>&1 && command -v rpm >/dev/null 2>&1; then
+  rpm_dir="$prefix/rpm-packages"
+  mkdir -p "$rpm_dir"
+  cpack --config "$build_dir/CPackConfig.cmake" -G RPM -C Release \
+    -B "$rpm_dir" >/dev/null || fail_test 'RPM generation failed'
+  rpms=( "$rpm_dir"/*.rpm(N) )
+  (( ${#rpms} == 1 )) || fail_test 'expected exactly one RPM package'
+  rpm_licenses=$(rpm -qp --licensefiles "$rpms[1]")
+  [[ $rpm_licenses == *'/usr/share/licenses/zpmod/NOTICE'* ]] ||
+    fail_test 'RPM does not mark NOTICE as a license file'
+  [[ $rpm_licenses == *'/usr/share/licenses/zpmod/LicenseRef-zsh.txt'* ]] ||
+    fail_test 'RPM does not mark the Zsh license text as a license file'
+fi
+
+# A non-default GNUInstallDirs data directory must flow into RPM file flags.
+custom_build="$prefix/custom-build"
+cmake -S "$source_root" -B "$custom_build" \
+  -DBUILD_TESTING=OFF \
+  -DCMAKE_INSTALL_DATADIR=custom-share >/dev/null ||
+  fail_test 'custom data-directory configure failed'
+grep -q '%license /usr/custom-share/licenses/zpmod/NOTICE' \
+  "$custom_build/CPackConfig.cmake" ||
+  fail_test 'RPM license paths ignore CMAKE_INSTALL_DATADIR'
+custom_prefix="$prefix/custom-prefix"
+cmake --install "$custom_build" --prefix "$custom_prefix" \
+  --component Licenses >/dev/null ||
+  fail_test 'custom data-directory license install failed'
+[[ -s "$custom_prefix/custom-share/licenses/zpmod/NOTICE" ]] ||
+  fail_test 'custom data-directory install omits NOTICE'
+
+absolute_data_dir="$prefix/absolute-share"
+absolute_build="$prefix/absolute-build"
+cmake -S "$source_root" -B "$absolute_build" \
+  -DBUILD_TESTING=OFF \
+  -DCMAKE_INSTALL_DATADIR="$absolute_data_dir" >/dev/null ||
+  fail_test 'absolute data-directory configure failed'
+grep -q "%license $absolute_data_dir/licenses/zpmod/NOTICE" \
+  "$absolute_build/CPackConfig.cmake" ||
+  fail_test 'RPM license paths corrupt an absolute CMAKE_INSTALL_DATADIR'
+cmake --install "$absolute_build" --prefix "$prefix/ignored-prefix" \
+  --component Licenses >/dev/null ||
+  fail_test 'absolute data-directory license install failed'
+[[ -s "$absolute_data_dir/licenses/zpmod/NOTICE" ]] ||
+  fail_test 'absolute data-directory install omits NOTICE'
+
+print -r -- 'package_license_payload OK'


### PR DESCRIPTION
## Summary

- document the existing file-specific MIT/Zsh license boundary without relicensing files
- add the full MIT text and a package-level NOTICE while retaining the upstream Zsh license
- install `LICENSE`, `LicenseRef-zsh.txt`, `MIT.txt`, `NOTICE`, and a full-text Debian-style copyright file
- mark all license payload files with RPM `%license` and align CPack metadata with `MIT AND LicenseRef-zsh`
- support default, relative custom, and absolute `CMAKE_INSTALL_DATADIR` values
- add actual TGZ inspection plus conditional DEB/RPM payload regression coverage

## Verification

- `scripts/cmake.configure.zsh --generator ninja --build-type Release --clean --ctest --ctest-jobs 2`: 47/47 passed
- generated TGZ contains `share/licenses/zpmod/{LICENSE,LicenseRef-zsh.txt,MIT.txt,NOTICE}` and `share/doc/zpmod/copyright`
- relative and absolute custom data-directory installs passed
- targeted Trunk prettier/markdownlint/git-diff checks passed
- `zsh -n tests/package/license_payload.zsh` passed
- independent final review passed with no security concerns or logic errors

## Scope

This records and ships the licenses already declared by file headers and the root LICENSE. It does not relicense any file or alter upstream notices.

Closes #95
