### PR TITLE
ci(release): enforce exact-tag publication gate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: docs-${{ github.ref }}
@@ -57,6 +55,10 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.validate.outputs.release_commit }}
+          ref: main
           submodules: recursive
           fetch-depth: 0
+
+      - name: Verify validated main commit
+        env:
+          RELEASE_COMMIT: ${{ needs.validate.outputs.release_commit }}
+        run: |
+          checked_out_commit=$(git rev-parse HEAD)
+          if [[ "$checked_out_commit" != "$RELEASE_COMMIT" ]]; then
+            echo "Release commit does not match checked-out main: $RELEASE_COMMIT != $checked_out_commit" >&2
+            exit 1
+          fi
 
       - name: Install build dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,70 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to build (optional - uses current ref if empty)"
-        required: false
-        default: ""
+        description: "Existing annotated vX.Y.Z tag to publish"
+        required: true
         type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-publication
   cancel-in-progress: false
 
 jobs:
+  validate:
+    name: Validate release boundary
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      release_commit: ${{ steps.ref.outputs.release_commit }}
+      release_tag: ${{ steps.ref.outputs.release_tag }}
+      release_tag_object: ${{ steps.ref.outputs.release_tag_object }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate annotated tag and ancestry
+        id: ref
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          release_commit=$(scripts/validate-release-ref.zsh "$RELEASE_TAG" origin/main origin)
+          release_tag_object=$(git rev-parse "refs/tags/$RELEASE_TAG")
+          echo "release_commit=$release_commit" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "release_tag_object=$release_tag_object" >> "$GITHUB_OUTPUT"
+
+      - name: Verify reviewed main provenance
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_COMMIT: ${{ steps.ref.outputs.release_commit }}
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/$GITHUB_REPOSITORY/commits/$RELEASE_COMMIT/pulls" \
+            > "$RUNNER_TEMP/associated-pulls.json"
+          jq -e \
+            'any(.[]; .merged_at != null and .base.ref == "main")' \
+            "$RUNNER_TEMP/associated-pulls.json" >/dev/null || {
+              echo "Release commit is not associated with a merged pull request into main" >&2
+              exit 1
+            }
+
   build:
     name: Build (${{ matrix.platform }})
+    needs: validate
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     permissions:
@@ -39,6 +82,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.validate.outputs.release_commit }}
           submodules: recursive
           fetch-depth: 0
 
@@ -68,11 +112,16 @@ jobs:
           brew update
           brew install autoconf automake libtool ncurses pcre2 gdbm texinfo ninja
 
-      - name: Configure project
+      - name: Configure, build, and run full suite
         run: |
-          ./scripts/cmake.configure.zsh --generator ninja --build-type Release --verbose
+          ./scripts/cmake.configure.zsh \
+            --generator ninja \
+            --build-type Release \
+            --verbose \
+            --ctest \
+            --ctest-jobs 2
 
-      - name: Build and package
+      - name: Package tested commit
         run: |
           # Select OS-specific CPack generators
           if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
@@ -80,7 +129,11 @@ jobs:
           else
             GEN="TGZ;TXZ"
           fi
-          ./scripts/cmake.configure.zsh --no-submodule --no-vendor-build --package --test --cpack-generators "$GEN"
+          ./scripts/cmake.configure.zsh \
+            --no-submodule \
+            --no-vendor-build \
+            --package \
+            --cpack-generators "$GEN"
 
       - name: Upload package artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -93,20 +146,20 @@ jobs:
             build-cmake/*.deb
             build-cmake/*.rpm
           retention-days: 30
-          if-no-files-found: ignore
+          if-no-files-found: error
 
   release:
     name: Create Release
-    needs: [build]
+    needs: [validate, build]
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Download all artifacts
@@ -118,20 +171,23 @@ jobs:
       - name: Prepare release assets
         run: |
           mkdir -p release-assets
-          find artifacts/ \( -name "*.tar.*" -o -name "*.zip" -o -name "*.dmg" -o -name "*.deb" -o -name "*.rpm" \) -type f -print0 \
-            | xargs -0 -I {} cp -v {} release-assets/ 2>/dev/null || true
+          find artifacts/ \( -name "*.tar.*" -o -name "*.zip" -o -name "*.dmg" -o -name "*.deb" -o -name "*.rpm" \) \
+            -type f -exec cp -v {} release-assets/ \;
           cd release-assets
-          if compgen -G "*.*" >/dev/null; then
-            sha256sum * > SHA256SUMS
-            sha256sum --check SHA256SUMS
-          fi
+          compgen -G "*.*" >/dev/null || {
+            echo "No release assets were downloaded" >&2
+            exit 1
+          }
+          sha256sum * > SHA256SUMS
+          sha256sum --check SHA256SUMS
           ls -la
 
       - name: Create Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
-          RELEASE_COMMIT: ${{ github.sha }}
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
+          RELEASE_COMMIT: ${{ needs.validate.outputs.release_commit }}
+          RELEASE_TAG_OBJECT: ${{ needs.validate.outputs.release_tag_object }}
         run: |
           cat > "$RUNNER_TEMP/release-notes.md" <<EOF
           Cross-platform zsh module release built from commit \`$RELEASE_COMMIT\`.
@@ -152,15 +208,72 @@ jobs:
           \`\`\`
           EOF
 
-          EXTRA_FLAGS=()
-          if [[ "$RELEASE_TAG" == *"-"* ]]; then
-            EXTRA_FLAGS+=( --prerelease )
+          current_commit=$(scripts/validate-release-ref.zsh "$RELEASE_TAG" origin/main origin)
+          current_tag_object=$(git rev-parse "refs/tags/$RELEASE_TAG")
+          if [[ "$current_commit" != "$RELEASE_COMMIT" ]]; then
+            echo "Release tag commit moved from $RELEASE_COMMIT to $current_commit" >&2
+            exit 1
           fi
+          if [[ "$current_tag_object" != "$RELEASE_TAG_OBJECT" ]]; then
+            echo "Release tag object moved from $RELEASE_TAG_OBJECT to $current_tag_object" >&2
+            exit 1
+          fi
+
+          if gh release view "$RELEASE_TAG" \
+            -R "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "A release already exists for $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          draft_created=false
+          draft_id=
+          cleanup_draft() {
+            [[ "$draft_created" == true ]] || return 0
+            if [[ -z "$draft_id" ]]; then
+              draft_id=$(gh api \
+                "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
+                --jq 'select(.draft == true) | .id' 2>/dev/null || true)
+            fi
+            [[ -n "$draft_id" ]] || return 0
+            current_draft=$(gh api \
+              "repos/$GITHUB_REPOSITORY/releases/$draft_id" \
+              --jq '.draft' 2>/dev/null || true)
+            if [[ "$current_draft" == true ]]; then
+              gh api -X DELETE \
+                "repos/$GITHUB_REPOSITORY/releases/$draft_id" \
+                >/dev/null 2>&1 || true
+            fi
+          }
+          trap cleanup_draft ERR
 
           gh release create "$RELEASE_TAG" release-assets/* \
             -R "${{ github.repository }}" \
             --target "$RELEASE_COMMIT" \
+            --verify-tag \
+            --draft \
             --title "zpmod $RELEASE_TAG" \
             --notes-file "$RUNNER_TEMP/release-notes.md" \
-            --generate-notes \
-            "${EXTRA_FLAGS[@]}"
+            --generate-notes
+
+          draft_created=true
+          draft_id=$(gh api \
+            "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
+            --jq 'select(.draft == true) | .id')
+          [[ -n "$draft_id" ]]
+
+          draft_commit=$(scripts/validate-release-ref.zsh "$RELEASE_TAG" origin/main origin)
+          draft_tag_object=$(git rev-parse "refs/tags/$RELEASE_TAG")
+          [[ "$draft_commit" == "$RELEASE_COMMIT" ]]
+          [[ "$draft_tag_object" == "$RELEASE_TAG_OBJECT" ]]
+
+          gh release edit "$RELEASE_TAG" \
+            -R "${{ github.repository }}" \
+            --draft=false \
+            --latest
+          draft_created=false
+          trap - ERR
+
+          published_commit=$(scripts/validate-release-ref.zsh "$RELEASE_TAG" origin/main origin)
+          published_tag_object=$(git rev-parse "refs/tags/$RELEASE_TAG")
+          [[ "$published_commit" == "$RELEASE_COMMIT" ]]
+          [[ "$published_tag_object" == "$RELEASE_TAG_OBJECT" ]]

--- a/scripts/validate-release-ref.zsh
+++ b/scripts/validate-release-ref.zsh
@@ -1,0 +1,46 @@
+#!/usr/bin/env zsh
+# Validate an immutable final-release boundary and print its commit SHA.
+emulate -L zsh
+set -euo pipefail
+
+release_tag=${1:-}
+main_ref=${2:-origin/main}
+remote=${3:-}
+
+if [[ ! $release_tag =~ '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' ]]; then
+  print -ru2 -- "release tag must match vX.Y.Z: ${release_tag:-<empty>}"
+  exit 1
+fi
+
+tag_ref="refs/tags/$release_tag"
+if [[ -n $remote ]]; then
+  git fetch --quiet --force --no-tags "$remote" \
+    "${tag_ref}:${tag_ref}" \
+    "refs/heads/main:${main_ref}" >/dev/null || {
+    print -ru2 -- "release refs are not available from $remote: $release_tag"
+    exit 1
+  }
+fi
+object_type=$(git cat-file -t "$tag_ref" 2>/dev/null) || {
+  print -ru2 -- "release tag does not exist: $release_tag"
+  exit 1
+}
+if [[ $object_type != tag ]]; then
+  print -ru2 -- "release tag must be annotated: $release_tag"
+  exit 1
+fi
+
+release_commit=$(git rev-parse --verify "${tag_ref}^{commit}" 2>/dev/null) || {
+  print -ru2 -- "release tag does not resolve to a commit: $release_tag"
+  exit 1
+}
+git rev-parse --verify "${main_ref}^{commit}" >/dev/null 2>&1 || {
+  print -ru2 -- "main reference does not exist: $main_ref"
+  exit 1
+}
+if ! git merge-base --is-ancestor "$release_commit" "$main_ref"; then
+  print -ru2 -- "$release_tag ($release_commit) is not reachable from $main_ref"
+  exit 1
+fi
+
+print -r -- "$release_commit"

--- a/scripts/validate-release-ref.zsh
+++ b/scripts/validate-release-ref.zsh
@@ -38,8 +38,9 @@ git rev-parse --verify "${main_ref}^{commit}" >/dev/null 2>&1 || {
   print -ru2 -- "main reference does not exist: $main_ref"
   exit 1
 }
-if ! git merge-base --is-ancestor "$release_commit" "$main_ref"; then
-  print -ru2 -- "$release_tag ($release_commit) is not reachable from $main_ref"
+main_commit=$(git rev-parse --verify "${main_ref}^{commit}")
+if [[ $release_commit != $main_commit ]]; then
+  print -ru2 -- "$release_tag ($release_commit) is not the current $main_ref tip ($main_commit)"
   exit 1
 fi
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,18 @@ set(ZPMOD_STAGE_MODULE_DIR "${ZPMOD_STAGE_DIR}/${ZPMOD_ZSH_MODDIR}")
 # Test categories for organization
 set(ZPMOD_TEST_LABELS "")
 
+add_test(NAME release_ref_validation
+  COMMAND ${ZSH_EXECUTABLE} -f ${CMAKE_CURRENT_SOURCE_DIR}/ci/release_ref_validation.zsh)
+set_tests_properties(release_ref_validation PROPERTIES
+  TIMEOUT 20
+  LABELS "ci;release;security")
+
+add_test(NAME release_workflow_policy
+  COMMAND ${ZSH_EXECUTABLE} -f ${CMAKE_CURRENT_SOURCE_DIR}/ci/release_workflow_policy.zsh)
+set_tests_properties(release_workflow_policy PROPERTIES
+  TIMEOUT 20
+  LABELS "ci;release;security")
+
 # Ensure the staged module exists before running any tests when invoking ctest directly.
 # We create a CTest fixture that builds the 'stage' target once and have tests require it.
 add_test(NAME stage_fixture

--- a/tests/ci/release_ref_validation.zsh
+++ b/tests/ci/release_ref_validation.zsh
@@ -1,0 +1,79 @@
+#!/usr/bin/env zsh
+# Deterministic tests for the release-ref validator.
+emulate -L zsh
+set -euo pipefail
+
+validator="${0:A:h:h:h}/scripts/validate-release-ref.zsh"
+workdir=$(mktemp -d 2>/dev/null || mktemp -d -t zpmod-release-ref)
+repo="$workdir/repo"
+mkdir -p "$repo"
+trap 'rm -rf -- "$workdir"' EXIT
+
+git -C "$repo" init -q -b main
+git -C "$repo" config user.name 'zpmod tests'
+git -C "$repo" config user.email 'zpmod-tests@example.invalid'
+print -r -- base >"$repo/file"
+git -C "$repo" add file
+git -C "$repo" commit -q -m 'test: base'
+base_commit=$(git -C "$repo" rev-parse HEAD)
+git -C "$repo" tag -a v1.2.3 -m 'v1.2.3'
+
+run_validator() {
+  (cd "$repo" && "$validator" "$@")
+}
+
+expect_failure() {
+  local description=$1
+  shift
+  if run_validator "$@" >/dev/null 2>&1; then
+    print -ru2 -- "validator unexpectedly accepted: $description"
+    exit 1
+  fi
+}
+
+actual=$(run_validator v1.2.3 refs/heads/main)
+[[ $actual == "$base_commit" ]] || {
+  print -ru2 -- "validator returned $actual, expected $base_commit"
+  exit 1
+}
+
+# Remote mode must refresh a stale local tag before returning a commit.
+remote="$workdir/remote.git"
+consumer="$workdir/consumer"
+git clone -q --bare "$repo" "$remote"
+git clone -q "$remote" "$consumer"
+remote_actual=$(cd "$consumer" &&
+  "$validator" v1.2.3 refs/remotes/origin/main origin)
+[[ $remote_actual == "$base_commit" ]] || {
+  print -ru2 -- "remote validator returned $remote_actual, expected $base_commit"
+  exit 1
+}
+git -C "$repo" commit -q --allow-empty -m 'test: move release candidate'
+moved_commit=$(git -C "$repo" rev-parse HEAD)
+git -C "$repo" tag -f -a v1.2.3 -m 'moved v1.2.3' >/dev/null
+git -C "$repo" push -q --force "$remote" main refs/tags/v1.2.3
+remote_actual=$(cd "$consumer" &&
+  "$validator" v1.2.3 refs/remotes/origin/main origin)
+[[ $remote_actual == "$moved_commit" ]] || {
+  print -ru2 -- "remote validator did not refresh moved tag"
+  exit 1
+}
+
+# Lightweight tags are not release boundaries.
+git -C "$repo" tag v1.2.4
+expect_failure 'lightweight tag' v1.2.4 refs/heads/main
+
+# Pre-release and malformed refs are outside the final vX.Y.Z boundary.
+git -C "$repo" tag -a v1.2.5-rc1 -m 'v1.2.5-rc1'
+expect_failure 'pre-release tag' v1.2.5-rc1 refs/heads/main
+expect_failure 'missing tag' v9.9.9 refs/heads/main
+expect_failure 'branch name' main refs/heads/main
+
+# A valid annotated tag on a commit outside main must fail closed.
+git -C "$repo" switch -q -c side
+git -C "$repo" commit -q --allow-empty -m 'test: side-only'
+git -C "$repo" tag -a v2.0.0 -m 'v2.0.0'
+git -C "$repo" switch -q main
+expect_failure 'tag not reachable from main' v2.0.0 refs/heads/main
+
+print -r -- 'release_ref_validation OK'

--- a/tests/ci/release_ref_validation.zsh
+++ b/tests/ci/release_ref_validation.zsh
@@ -59,6 +59,11 @@ remote_actual=$(cd "$consumer" &&
   exit 1
 }
 
+# A reviewed ancestor is insufficient: publication must use the current main
+# tip so the release workflow never executes a dynamically selected checkout.
+git -C "$repo" tag -a v1.3.0 "$base_commit" -m 'v1.3.0 on old main'
+expect_failure 'tag on an old main ancestor' v1.3.0 refs/heads/main
+
 # Lightweight tags are not release boundaries.
 git -C "$repo" tag v1.2.4
 expect_failure 'lightweight tag' v1.2.4 refs/heads/main

--- a/tests/ci/release_workflow_policy.zsh
+++ b/tests/ci/release_workflow_policy.zsh
@@ -1,0 +1,59 @@
+#!/usr/bin/env zsh
+# Static policy checks for release and Pages workflows.
+emulate -L zsh
+set -euo pipefail
+
+repo_root=${0:A:h:h:h}
+release="$repo_root/.github/workflows/release.yml"
+docs="$repo_root/.github/workflows/docs.yml"
+
+fail_test() {
+  print -ru2 -- "$*"
+  exit 1
+}
+
+grep -q '^  workflow_dispatch:' "$release" ||
+  fail_test 'release workflow lacks the explicit publication gate'
+grep -q '^        required: true' "$release" ||
+  fail_test 'release tag input is not mandatory'
+if grep -q '^  push:' "$release"; then
+  fail_test 'release workflow still publishes automatically on tag push'
+fi
+grep -q 'validate-release-ref.zsh' "$release" ||
+  fail_test 'release workflow does not validate the release ref'
+grep -q -- '--ctest' "$release" ||
+  fail_test 'release workflow does not run the full CTest suite'
+grep -q 'needs: validate' "$release" ||
+  fail_test 'release builds are not gated by ref validation'
+grep -q -- '--verify-tag' "$release" ||
+  fail_test 'release publication does not require the remote tag'
+grep -q -- '--draft' "$release" ||
+  fail_test 'release assets are uploaded directly to a public release'
+grep -q 'gh release edit' "$release" ||
+  fail_test 'release workflow does not publish a validated draft'
+grep -q 'cleanup_draft' "$release" ||
+  fail_test 'failed draft validation does not clean up the private release'
+grep -q 'draft_id=' "$release" ||
+  fail_test 'draft cleanup is not scoped to a release ID'
+if grep -q 'gh release delete.*RELEASE_TAG' "$release"; then
+  fail_test 'draft cleanup can delete a pre-existing release by tag'
+fi
+grep -q 'Release tag object moved' "$release" ||
+  fail_test 'release publication does not revalidate after the builds'
+
+# Workflow-scope Docs permissions end at the concurrency key.
+docs_top_permissions=$(sed -n '/^permissions:/,/^concurrency:/p' "$docs")
+[[ $docs_top_permissions == *'contents: read'* ]] ||
+  fail_test 'Docs workflow lacks workflow-scope contents: read'
+[[ $docs_top_permissions != *'pages: write'* ]] ||
+  fail_test 'Docs workflow grants pages: write to PR build jobs'
+[[ $docs_top_permissions != *'id-token: write'* ]] ||
+  fail_test 'Docs workflow grants id-token: write to PR build jobs'
+
+deploy_block=$(sed -n '/^  deploy:/,$p' "$docs")
+[[ $deploy_block == *'pages: write'* ]] ||
+  fail_test 'Docs deploy job lacks pages: write'
+[[ $deploy_block == *'id-token: write'* ]] ||
+  fail_test 'Docs deploy job lacks id-token: write'
+
+print -r -- 'release_workflow_policy OK'

--- a/tests/ci/release_workflow_policy.zsh
+++ b/tests/ci/release_workflow_policy.zsh
@@ -25,6 +25,11 @@ grep -q -- '--ctest' "$release" ||
   fail_test 'release workflow does not run the full CTest suite'
 grep -q 'needs: validate' "$release" ||
   fail_test 'release builds are not gated by ref validation'
+if grep -q 'ref:.*needs.validate.outputs.release_commit' "$release"; then
+  fail_test 'release build executes a dynamically selected checkout'
+fi
+grep -q 'Release commit does not match checked-out main' "$release" ||
+  fail_test 'release build does not prove it is executing validated main'
 grep -q -- '--verify-tag' "$release" ||
   fail_test 'release publication does not require the remote tag'
 grep -q -- '--draft' "$release" ||


### PR DESCRIPTION
## Summary

- replace automatic tag-push publication with an explicit, mandatory `vX.Y.Z` workflow-dispatch gate from `main`
- validate strict annotated tags, refreshed remote tag/main refs, main ancestry, and merged-PR provenance before release builds
- check out and run the complete CTest suite on the exact validated commit on each release platform before packaging
- carry both peeled commit and annotated tag-object IDs across jobs and re-fetch them before publication
- upload assets to a private draft, clean up only the draft ID created by this run on validation failure, then publish after revalidation
- require `gh release create --verify-tag` and verify refs once more after publication
- fail when package artifacts are absent and scope Pages write/OIDC permissions to the deploy job
- add deterministic release-ref, moved-tag, and workflow-policy tests

## Verification

- `scripts/cmake.configure.zsh --generator ninja --build-type Release --clean --ctest --ctest-jobs 2`: 48/48 passed
- `actionlint .github/workflows/release.yml .github/workflows/docs.yml`: passed
- targeted Trunk actionlint/yamllint/prettier/git-diff checks passed
- `zsh -n` for all new scripts passed
- independent final review passed every draft-cleanup, ref-validation, exact-commit, and test-order check

## Release safety

No tag, workflow dispatch, release, or repository setting was changed. Invalid, lightweight, prerelease, branch-named, missing, moved, deleted, and non-main-reachable refs fail closed in the validated path.

Closes #94
