### PR TITLE
ci: restore minimum-Zsh and latest-Zi coverage

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,105 @@
+name: Compatibility
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  latest-zi:
+    name: Latest Zi Integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            cmake \
+            ninja-build \
+            autotools-dev \
+            autoconf \
+            automake \
+            pkg-config \
+            libtool \
+            texinfo \
+            yodl \
+            libncurses5-dev \
+            libpcre3-dev \
+            libgdbm-dev \
+            zsh
+
+      - name: Prepare latest Zi and candidate revision
+        run: |
+          set -euo pipefail
+          integration_root=$(mktemp -d "$RUNNER_TEMP/zpmod-zi.XXXXXX")
+          zi_home="$integration_root/home"
+          candidate_remote="$integration_root/zpmod-candidate.git"
+          mkdir -p "$zi_home/.zi/zmodules"
+
+          git clone --depth 1 https://github.com/z-shell/zi.git \
+            "$zi_home/.zi/bin"
+          zi_revision=$(git -C "$zi_home/.zi/bin" rev-parse HEAD)
+
+          git init --bare --quiet "$candidate_remote"
+          git push --quiet "$candidate_remote" HEAD:refs/heads/ci-candidate
+          git --git-dir="$candidate_remote" symbolic-ref \
+            HEAD refs/heads/ci-candidate
+          git clone --quiet "$candidate_remote" \
+            "$zi_home/.zi/zmodules/zpmod"
+
+          candidate_revision=$(git rev-parse HEAD)
+          printf 'ZI_TEST_HOME=%s\n' "$zi_home" >> "$GITHUB_ENV"
+          printf 'ZI_REVISION=%s\n' "$zi_revision" >> "$GITHUB_ENV"
+          printf 'ZPMOD_EXPECTED_REVISION=%s\n' \
+            "$candidate_revision" >> "$GITHUB_ENV"
+          printf 'Zi revision: `%s`\n' "$zi_revision" >> "$GITHUB_STEP_SUMMARY"
+          printf 'Candidate revision: `%s`\n' \
+            "$candidate_revision" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build candidate through Zi
+        run: |
+          HOME="$ZI_TEST_HOME" \
+            ZDOTDIR="$ZI_TEST_HOME" \
+            XDG_CACHE_HOME="$ZI_TEST_HOME/.cache" \
+            zsh -f -c '
+            source "$HOME/.zi/bin/zi.zsh" || exit 1
+            zi module build --from-source
+          '
+
+      - name: Verify Zi-managed candidate
+        run: |
+          set -euo pipefail
+          module_root="$ZI_TEST_HOME/.zi/zmodules/zpmod"
+          actual_revision=$(git -C "$module_root" rev-parse HEAD)
+          if [[ "$actual_revision" != "$ZPMOD_EXPECTED_REVISION" ]]; then
+            printf 'Zi built revision %s instead of %s\n' \
+              "$actual_revision" "$ZPMOD_EXPECTED_REVISION" >&2
+            exit 1
+          fi
+          test -s "$module_root/Src/zi/zpmod.so"
+          HOME="$ZI_TEST_HOME" \
+            ZDOTDIR="$ZI_TEST_HOME" \
+            XDG_CACHE_HOME="$ZI_TEST_HOME/.cache" \
+            ZPMOD_MODULE_ROOT="$module_root" \
+            zsh -f -c '
+              emulate -R zsh
+              module_path=( "$ZPMOD_MODULE_ROOT/Src" $module_path )
+              zmodload -i zi/zpmod || exit 1
+              [[ $(whence -w zpmod) == *builtin* ]]
+            '

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ zpmod source-study
   [docs/how-to/install-zpmod-with-cmake.md](docs/how-to/install-zpmod-with-cmake.md).
 - Install to a custom directory: see [docs/how-to/install-custom-dir.md](docs/how-to/install-custom-dir.md).
 
+## Compatibility
+
+The minimum supported Zsh release is 5.8.1. Prebuilt module compatibility is limited to the platform, architecture, and Zsh combinations
+exercised by the release and compatibility workflows. See the [compatibility reference](docs/reference/compatibility.md) for the package ABI
+policy and verification coverage.
+
 ## Documentation
 
 Full documentation lives under [docs/](docs/index.md), organized as tutorials, how-to guides, reference, and explanation.

--- a/docker/minimal.Dockerfile
+++ b/docker/minimal.Dockerfile
@@ -13,6 +13,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
+# Fail closed if the distribution package stops providing the documented floor.
+ARG ZPMOD_MINIMUM_ZSH=5.8.1
+RUN actual_version="$(zsh -fc 'print -r -- "$ZSH_VERSION"')" && \
+    if [ "$actual_version" != "$ZPMOD_MINIMUM_ZSH" ]; then \
+      printf 'Expected Zsh %s, found %s\n' \
+        "$ZPMOD_MINIMUM_ZSH" "$actual_version" >&2; \
+      exit 1; \
+    fi && \
+    printf 'Using minimum supported Zsh %s\n' "$actual_version"
+
 # Create non-root user for running tests so permission checks (EACCES) behave as expected
 RUN useradd -m -u 1000 -U zp
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -6,3 +6,4 @@ Authoritative, detail-first sections:
 - [Environment Variables](environment.md)
 - [CLI / Subcommands](cli.md)
 - [CMake Build & Install Helper](install-cmake-helper.md)
+- [Compatibility](compatibility.md)

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -1,0 +1,24 @@
+# Compatibility
+
+## Zsh version floor
+
+The minimum supported Zsh release is **5.8.1**. The minimum-version container asserts that exact runtime before it builds the module and
+runs the complete CTest suite. Native Linux and macOS jobs also run the full suite against their current Zsh environments.
+
+A scheduled compatibility workflow builds the candidate revision through the latest Zi default branch, records the exact Zi revision, and
+loads the resulting `zi/zpmod` module. This integration is a compatibility probe, not a dependency pin for end users.
+
+## Prebuilt-package ABI policy
+
+`zpmod` does not promise a universal Zsh module ABI across Zsh releases, operating systems, C libraries, or processor architectures. A
+prebuilt package is supported only for the platform, architecture, and Zsh combinations exercised by the release and compatibility workflows
+for that package revision.
+
+The Zsh 5.8.1 source-compatibility floor does not imply that a binary built for another Zsh or platform combination will load safely. If a
+published package does not match an exercised combination, build `zpmod` from source on the target system.
+
+## Package-installation coverage
+
+The full CTest suite generates a TGZ package, extracts it into an isolated prefix, loads the packaged module, verifies the `zpmod` builtin,
+and confirms that the packaged `_zpmod` completion is autoloadable. This checks the installed layout rather than relying only on a
+source-tree build.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,12 @@ set_tests_properties(release_workflow_policy PROPERTIES
   TIMEOUT 20
   LABELS "ci;release;security")
 
+add_test(NAME compatibility_policy
+  COMMAND ${ZSH_EXECUTABLE} -f ${CMAKE_CURRENT_SOURCE_DIR}/ci/compatibility_policy.zsh)
+set_tests_properties(compatibility_policy PROPERTIES
+  TIMEOUT 20
+  LABELS "ci;compat;package")
+
 add_test(NAME package_license_payload
   COMMAND ${ZSH_EXECUTABLE} -f ${CMAKE_CURRENT_SOURCE_DIR}/package/license_payload.zsh)
 set_tests_properties(package_license_payload PROPERTIES
@@ -30,6 +36,14 @@ set_tests_properties(package_license_payload PROPERTIES
   FIXTURES_REQUIRED "StageReady"
   TIMEOUT 30
   LABELS "package;license;release")
+
+add_test(NAME package_install_smoke
+  COMMAND ${ZSH_EXECUTABLE} -f ${CMAKE_CURRENT_SOURCE_DIR}/package/install_smoke.zsh)
+set_tests_properties(package_install_smoke PROPERTIES
+  ENVIRONMENT "ZPMOD_BUILD_DIR=${CMAKE_BINARY_DIR}"
+  FIXTURES_REQUIRED "StageReady"
+  TIMEOUT 30
+  LABELS "package;install;compat;release")
 
 # Ensure the staged module exists before running any tests when invoking ctest directly.
 # We create a CTest fixture that builds the 'stage' target once and have tests require it.

--- a/tests/ci/compatibility_policy.zsh
+++ b/tests/ci/compatibility_policy.zsh
@@ -1,0 +1,44 @@
+#!/usr/bin/env zsh
+# Keep the documented compatibility floor aligned with its executable CI gates.
+emulate -R zsh
+setopt err_exit no_unset pipe_fail
+
+typeset repo_root=${0:A:h:h:h}
+typeset minimum_zsh=5.8.1
+typeset dockerfile="$repo_root/docker/minimal.Dockerfile"
+typeset workflow="$repo_root/.github/workflows/compatibility.yml"
+typeset compatibility_doc="$repo_root/docs/reference/compatibility.md"
+
+fail_test() {
+  print -ru2 -- "$*"
+  exit 1
+}
+
+grep -Fq "ARG ZPMOD_MINIMUM_ZSH=$minimum_zsh" "$dockerfile" ||
+  fail_test "minimum container does not pin Zsh $minimum_zsh"
+grep -Fq 'actual_version=' "$dockerfile" ||
+  fail_test 'minimum container does not inspect the installed Zsh version'
+grep -Fq 'ZPMOD_MINIMUM_ZSH' "$dockerfile" ||
+  fail_test 'minimum container does not enforce its declared Zsh version'
+
+[[ -f $workflow ]] || fail_test 'scheduled compatibility workflow is missing'
+grep -Fq 'schedule:' "$workflow" ||
+  fail_test 'compatibility workflow is not scheduled'
+grep -Fq 'zi module build --from-source' "$workflow" ||
+  fail_test 'compatibility workflow does not build the candidate through Zi'
+grep -Fq 'ZI_REVISION=' "$workflow" ||
+  fail_test 'compatibility workflow does not record the Zi revision'
+grep -Fq 'ZPMOD_EXPECTED_REVISION=' "$workflow" ||
+  fail_test 'compatibility workflow does not preserve the candidate revision'
+grep -Fq 'zmodload -i zi/zpmod' "$workflow" ||
+  fail_test 'compatibility workflow does not load the Zi-managed module'
+
+[[ -f $compatibility_doc ]] || fail_test 'compatibility reference is missing'
+grep -Fq "minimum supported Zsh release is **$minimum_zsh**" \
+  "$compatibility_doc" ||
+  fail_test "documentation does not declare Zsh $minimum_zsh as the floor"
+grep -Fq 'does not promise a universal Zsh module ABI' \
+  "$compatibility_doc" ||
+  fail_test 'documentation does not define the prebuilt-package ABI boundary'
+
+print -r -- 'compatibility_policy OK'

--- a/tests/package/install_smoke.zsh
+++ b/tests/package/install_smoke.zsh
@@ -1,0 +1,52 @@
+#!/usr/bin/env zsh
+# Generate and load the TGZ payload rather than testing only the source tree.
+emulate -R zsh
+setopt err_exit no_unset pipe_fail
+
+typeset source_root=${0:A:h:h:h}
+typeset build_dir=${ZPMOD_BUILD_DIR:-$source_root/build-cmake}
+typeset scratch
+typeset package_dir extract_dir
+typeset -a archives package_roots module_files completion_files
+typeset -a original_module_path original_fpath
+scratch=$(mktemp -d 2>/dev/null || mktemp -d -t zpmod-package-smoke)
+trap 'rm -rf -- "$scratch"' EXIT
+
+fail_test() {
+  print -ru2 -- "$*"
+  exit 1
+}
+
+package_dir="$scratch/packages"
+extract_dir="$scratch/extracted"
+mkdir -p -- "$package_dir" "$extract_dir" "$scratch/home" "$scratch/zdotdir"
+export HOME="$scratch/home"
+export ZDOTDIR="$scratch/zdotdir"
+
+cpack --config "$build_dir/CPackConfig.cmake" -G TGZ -C Release \
+  -B "$package_dir" >/dev/null || fail_test 'TGZ generation failed'
+archives=( "$package_dir"/*.tar.gz(N) )
+(( ${#archives} == 1 )) || fail_test 'expected exactly one TGZ package'
+tar -xzf "$archives[1]" -C "$extract_dir" ||
+  fail_test 'TGZ extraction failed'
+
+package_roots=( "$extract_dir"/*(N/) )
+(( ${#package_roots} == 1 )) || fail_test 'expected one package root'
+module_files=( "$package_roots[1]"/**/lib/zsh/site-modules/zpmod.*(N.) )
+completion_files=( "$package_roots[1]"/**/share/zsh/site-functions/_zpmod(N.) )
+(( ${#module_files} == 1 )) || fail_test 'package lacks one loadable zpmod module'
+(( ${#completion_files} == 1 )) || fail_test 'package lacks the _zpmod completion'
+
+original_module_path=( "${module_path[@]}" )
+module_path=( "${module_files[1]:h}" "${original_module_path[@]}" )
+zmodload -i zpmod || fail_test 'packaged module failed to load'
+[[ $(whence -w zpmod) == *builtin* ]] ||
+  fail_test 'packaged module did not register the zpmod builtin'
+
+original_fpath=( "${fpath[@]}" )
+fpath=( "${completion_files[1]:h}" "${original_fpath[@]}" )
+autoload -Uz _zpmod
+[[ $(whence -w _zpmod) == *function* ]] ||
+  fail_test 'packaged completion is not autoloadable'
+
+print -r -- 'package_install_smoke OK'


### PR DESCRIPTION
## Summary

- enforce Zsh 5.8.1 as the documented and executable compatibility floor
- restore scheduled latest-Zi source-build and module-load coverage
- test an extracted TGZ package, including its module and completion layout
- document the prebuilt module ABI support boundary

## Verification

- native Zsh 5.9.2: 52/52 CTests passed
- Ubuntu 22.04 with exact Zsh 5.8.1: 52/52 CTests passed
- committed candidate `5c45100190bf55cb012210abdec8b79a093bb56d` built and loaded through latest Zi revision `174a3d5d4fb9216fa028a29b39868ab6b61e0e38`
- generated TGZ extracted successfully; packaged module loaded, `zpmod` builtin registered, and `_zpmod` completion autoloaded
- Actionlint, YAML parsing, native Zsh syntax, `zcompile`, focused Trunk checks, and diff checks passed

Closes #97
