### PR TITLE
fix(release): provision validation dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,18 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      - name: Install validation dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh
+
       - name: Validate annotated tag and ancestry
         id: ref
         env:
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          release_commit=$(scripts/validate-release-ref.zsh "$RELEASE_TAG" origin/main origin)
+          release_commit=$(scripts/validate-release-ref.zsh \
+            "$RELEASE_TAG" refs/remotes/origin/main origin)
           release_tag_object=$(git rev-parse "refs/tags/$RELEASE_TAG")
           echo "release_commit=$release_commit" >> "$GITHUB_OUTPUT"
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"

--- a/scripts/validate-release-ref.zsh
+++ b/scripts/validate-release-ref.zsh
@@ -14,6 +14,11 @@ fi
 
 tag_ref="refs/tags/$release_tag"
 if [[ -n $remote ]]; then
+  if [[ $main_ref != refs/* ]]; then
+    print -ru2 -- \
+      "remote validation requires a fully qualified main ref: $main_ref"
+    exit 1
+  fi
   git fetch --quiet --force --no-tags "$remote" \
     "${tag_ref}:${tag_ref}" \
     "refs/heads/main:${main_ref}" >/dev/null || {

--- a/tests/ci/release_ref_validation.zsh
+++ b/tests/ci/release_ref_validation.zsh
@@ -48,6 +48,15 @@ remote_actual=$(cd "$consumer" &&
   print -ru2 -- "remote validator returned $remote_actual, expected $base_commit"
   exit 1
 }
+if (cd "$consumer" &&
+  "$validator" v1.2.3 origin/main origin) >/dev/null 2>&1; then
+  print -ru2 -- 'remote validator accepted an ambiguous shorthand main ref'
+  exit 1
+fi
+[[ ! -e "$consumer/.git/refs/heads/origin/main" ]] || {
+  print -ru2 -- 'remote validator created an ambiguous local origin/main branch'
+  exit 1
+}
 git -C "$repo" commit -q --allow-empty -m 'test: move release candidate'
 moved_commit=$(git -C "$repo" rev-parse HEAD)
 git -C "$repo" tag -f -a v1.2.3 -m 'moved v1.2.3' >/dev/null

--- a/tests/ci/release_workflow_policy.zsh
+++ b/tests/ci/release_workflow_policy.zsh
@@ -21,6 +21,14 @@ if grep -q '^  push:' "$release"; then
 fi
 grep -q 'validate-release-ref.zsh' "$release" ||
   fail_test 'release workflow does not validate the release ref'
+grep -q 'sudo apt-get install -y zsh' "$release" ||
+  fail_test 'release validation does not provision Zsh'
+install_line=$(grep -n -m1 'sudo apt-get install -y zsh' "$release")
+validate_line=$(grep -n -m1 'name: Validate annotated tag' "$release")
+(( ${install_line%%:*} < ${validate_line%%:*} )) ||
+  fail_test 'release validation provisions Zsh after invoking the validator'
+grep -q 'refs/remotes/origin/main origin' "$release" ||
+  fail_test 'release validation does not use a fully qualified main ref'
 grep -q -- '--ctest' "$release" ||
   fail_test 'release workflow does not run the full CTest suite'
 grep -q 'needs: validate' "$release" ||


### PR DESCRIPTION
## Summary

- install Zsh before the release workflow invokes its Zsh validator
- require fully qualified main refs during remote release validation
- add regression coverage for both release-bootstrap failures

## Failure addressed

Release run [33060334762](https://github.com/z-shell/zpmod/actions/runs/33060334762) stopped before validation with:

```text
/usr/bin/env: ‘zsh’: No such file or directory
```

Local reproduction also showed that passing shorthand `origin/main` creates `refs/heads/origin/main` beside `refs/remotes/origin/main`, making later Git commands ambiguous.

## Verification

- both new tests failed before the implementation for their intended reasons
- committed candidate `94d1e8c522317abb2cf86287796c2c57ac208404`: 52/52 CTests passed
- native Zsh syntax and `zcompile` passed
- Actionlint and diff checks passed
- Trunk could not start in the absorbed submodule checkout because it reported `reference 'HEAD' not found`; it produced no lint finding

Refs #96
