### PR TITLE
fix(release): provision publication validator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,11 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      - name: Install validation dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh
+
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -224,7 +229,8 @@ jobs:
           \`\`\`
           EOF
 
-          current_commit=$(scripts/validate-release-ref.zsh "$RELEASE_TAG" origin/main origin)
+          current_commit=$(scripts/validate-release-ref.zsh \
+            "$RELEASE_TAG" refs/remotes/origin/main origin)
           current_tag_object=$(git rev-parse "refs/tags/$RELEASE_TAG")
           if [[ "$current_commit" != "$RELEASE_COMMIT" ]]; then
             echo "Release tag commit moved from $RELEASE_COMMIT to $current_commit" >&2
@@ -277,7 +283,8 @@ jobs:
             --jq 'select(.draft == true) | .id')
           [[ -n "$draft_id" ]]
 
-          draft_commit=$(scripts/validate-release-ref.zsh "$RELEASE_TAG" origin/main origin)
+          draft_commit=$(scripts/validate-release-ref.zsh \
+            "$RELEASE_TAG" refs/remotes/origin/main origin)
           draft_tag_object=$(git rev-parse "refs/tags/$RELEASE_TAG")
           [[ "$draft_commit" == "$RELEASE_COMMIT" ]]
           [[ "$draft_tag_object" == "$RELEASE_TAG_OBJECT" ]]
@@ -289,7 +296,8 @@ jobs:
           draft_created=false
           trap - ERR
 
-          published_commit=$(scripts/validate-release-ref.zsh "$RELEASE_TAG" origin/main origin)
+          published_commit=$(scripts/validate-release-ref.zsh \
+            "$RELEASE_TAG" refs/remotes/origin/main origin)
           published_tag_object=$(git rev-parse "refs/tags/$RELEASE_TAG")
           [[ "$published_commit" == "$RELEASE_COMMIT" ]]
           [[ "$published_tag_object" == "$RELEASE_TAG_OBJECT" ]]

--- a/tests/ci/release_workflow_policy.zsh
+++ b/tests/ci/release_workflow_policy.zsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 # Static policy checks for release and Pages workflows.
-emulate -L zsh
-set -euo pipefail
+emulate -R zsh
+setopt err_exit no_unset pipe_fail
 
 repo_root=${0:A:h:h:h}
 release="$repo_root/.github/workflows/release.yml"
@@ -19,16 +19,44 @@ grep -q '^        required: true' "$release" ||
 if grep -q '^  push:' "$release"; then
   fail_test 'release workflow still publishes automatically on tag push'
 fi
-grep -q 'validate-release-ref.zsh' "$release" ||
+typeset current_job=''
+typeset line
+typeset -i in_jobs=0
+typeset -i job_has_apt_update=0
+typeset -i job_has_zsh=0
+typeset -i validator_invocations=0
+typeset -i qualified_main_refs=0
+
+while IFS= read -r line || [[ -n $line ]]; do
+  if [[ $line == jobs: ]]; then
+    in_jobs=1
+    continue
+  fi
+  (( in_jobs )) || continue
+
+  if [[ $line == '  '*: && $line != '   '* ]]; then
+    current_job=${${line#  }%:}
+    job_has_apt_update=0
+    job_has_zsh=0
+    continue
+  fi
+
+  [[ $line == *'sudo apt-get update'* ]] && job_has_apt_update=1
+  [[ $line == *'sudo apt-get install -y zsh'* ]] && job_has_zsh=1
+  if [[ $line == *'validate-release-ref.zsh'* ]]; then
+    [[ -n $current_job ]] ||
+      fail_test 'release validator invocation is outside a job'
+    (( ++validator_invocations ))
+    (( job_has_apt_update && job_has_zsh )) ||
+      fail_test "release job $current_job invokes the validator before provisioning Zsh"
+  fi
+done < "$release"
+
+(( validator_invocations > 0 )) ||
   fail_test 'release workflow does not validate the release ref'
-grep -q 'sudo apt-get install -y zsh' "$release" ||
-  fail_test 'release validation does not provision Zsh'
-install_line=$(grep -n -m1 'sudo apt-get install -y zsh' "$release")
-validate_line=$(grep -n -m1 'name: Validate annotated tag' "$release")
-(( ${install_line%%:*} < ${validate_line%%:*} )) ||
-  fail_test 'release validation provisions Zsh after invoking the validator'
-grep -q 'refs/remotes/origin/main origin' "$release" ||
-  fail_test 'release validation does not use a fully qualified main ref'
+qualified_main_refs=$(grep -c 'refs/remotes/origin/main origin' "$release" || true)
+(( qualified_main_refs == validator_invocations )) ||
+  fail_test 'not every release validator invocation uses a fully qualified main ref'
 grep -q -- '--ctest' "$release" ||
   fail_test 'release workflow does not run the full CTest suite'
 grep -q 'needs: validate' "$release" ||


### PR DESCRIPTION
## Summary

- provision Zsh in the Create Release job before any release-ref validation
- pass the fully qualified `refs/remotes/origin/main` ref to all three publication-stage validator calls
- make the workflow policy test enumerate every validator invocation and require job-local `apt-get update`, Zsh installation, and a fully qualified remote-main ref

Refs #96

## Failure reproduced

Before the workflow repair, the new policy regression failed with:

```text
release job release invokes the validator before provisioning Zsh
```

The previous v2.0.3 run failed at the same Create Release boundary before draft creation:

```text
/usr/bin/env: zsh: No such file or directory
```

## Verification

- `ctest --test-dir build-cmake --output-on-failure -j2`: 52/52 passed on committed candidate `ed822ae2d7a14ac583dfd084f10de3b644a53caf`
- policy regression under system Zsh and the repository-staged Zsh: passed
- release-ref validation test: passed
- `zsh -f -n` and `zcompile`: passed
- Actionlint, Prettier 3.6.2, Yamllint 1.37.1, Gitleaks, and `git diff --check`: passed

Trunk 1.25.0 could not start in this absorbed submodule checkout because its Git layer reported `reference 'HEAD' not found`. The individual pinned formatter and linter binaries completed successfully, and the commit used the organization commit-message hook under explicit maintainer approval.

## Release boundary

This PR does not create, move, or publish a tag or release. The v2.0.2 and v2.0.3 tags remain unchanged and unpublished. A v2.0.4 tag and workflow dispatch require separate maintainer approval after this change is merged and the exact merged-main checks are green.
