### PR TITLE
fix(release): bind draft operations to release ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,15 +252,21 @@ jobs:
           cleanup_draft() {
             [[ "$draft_created" == true ]] || return 0
             if [[ -z "$draft_id" ]]; then
-              draft_id=$(gh api \
-                "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
-                --jq 'select(.draft == true) | .id' 2>/dev/null || true)
+              draft_id=$(scripts/resolve-release-draft.zsh \
+                "$GITHUB_REPOSITORY" \
+                "$RELEASE_TAG" \
+                "$RELEASE_COMMIT" 2>/dev/null || true)
             fi
             [[ -n "$draft_id" ]] || return 0
-            current_draft=$(gh api \
-              "repos/$GITHUB_REPOSITORY/releases/$draft_id" \
-              --jq '.draft' 2>/dev/null || true)
-            if [[ "$current_draft" == true ]]; then
+            current_release=$(gh api \
+              "repos/$GITHUB_REPOSITORY/releases/$draft_id" 2>/dev/null || true)
+            if jq -e \
+              --arg tag "$RELEASE_TAG" \
+              --arg commit "$RELEASE_COMMIT" \
+              '.draft == true and
+                .tag_name == $tag and
+                .target_commitish == $commit' \
+              <<< "$current_release" >/dev/null 2>&1; then
               gh api -X DELETE \
                 "repos/$GITHUB_REPOSITORY/releases/$draft_id" \
                 >/dev/null 2>&1 || true
@@ -278,10 +284,21 @@ jobs:
             --generate-notes
 
           draft_created=true
-          draft_id=$(gh api \
-            "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
-            --jq 'select(.draft == true) | .id')
-          [[ -n "$draft_id" ]]
+          draft_id=$(scripts/resolve-release-draft.zsh \
+            "$GITHUB_REPOSITORY" \
+            "$RELEASE_TAG" \
+            "$RELEASE_COMMIT")
+          draft_release=$(gh api \
+            "repos/$GITHUB_REPOSITORY/releases/$draft_id")
+          jq -e \
+            --arg tag "$RELEASE_TAG" \
+            --arg commit "$RELEASE_COMMIT" \
+            --argjson id "$draft_id" \
+            '.id == $id and
+              .draft == true and
+              .tag_name == $tag and
+              .target_commitish == $commit' \
+            <<< "$draft_release" >/dev/null
 
           draft_commit=$(scripts/validate-release-ref.zsh \
             "$RELEASE_TAG" refs/remotes/origin/main origin)
@@ -289,10 +306,22 @@ jobs:
           [[ "$draft_commit" == "$RELEASE_COMMIT" ]]
           [[ "$draft_tag_object" == "$RELEASE_TAG_OBJECT" ]]
 
-          gh release edit "$RELEASE_TAG" \
-            -R "${{ github.repository }}" \
-            --draft=false \
-            --latest
+          gh api -X PATCH \
+            "repos/$GITHUB_REPOSITORY/releases/$draft_id" \
+            -F draft=false \
+            -f make_latest=true >/dev/null
+          published_release=$(gh api \
+            "repos/$GITHUB_REPOSITORY/releases/$draft_id")
+          jq -e \
+            --arg tag "$RELEASE_TAG" \
+            --arg commit "$RELEASE_COMMIT" \
+            --argjson id "$draft_id" \
+            '.id == $id and
+              .draft == false and
+              .tag_name == $tag and
+              .target_commitish == $commit and
+              .published_at != null' \
+            <<< "$published_release" >/dev/null
           draft_created=false
           trap - ERR
 

--- a/scripts/resolve-release-draft.zsh
+++ b/scripts/resolve-release-draft.zsh
@@ -1,0 +1,43 @@
+#!/usr/bin/env zsh
+# Resolve exactly one private release draft by tag and target commit.
+emulate -R zsh
+setopt err_exit no_unset pipe_fail
+
+if (( $# != 3 )); then
+  print -ru2 -- \
+    'usage: resolve-release-draft.zsh <owner/repository> <tag> <commit>'
+  exit 2
+fi
+
+typeset repository=$1
+typeset release_tag=$2
+typeset release_commit=$3
+typeset releases_json draft_ids_output
+typeset -a draft_ids
+
+releases_json=$(gh api --paginate --slurp \
+  "repos/$repository/releases?per_page=100")
+draft_ids_output=$(jq -r \
+  --arg tag "$release_tag" \
+  --arg commit "$release_commit" \
+  '.[][] | select(
+    .draft == true and
+    .tag_name == $tag and
+    .target_commitish == $commit
+  ) | .id' <<< "$releases_json")
+draft_ids=( ${(f)draft_ids_output} )
+
+if (( ${#draft_ids[@]} != 1 )); then
+  print -ru2 -- \
+    "expected exactly one draft for $release_tag at $release_commit; found ${#draft_ids[@]}"
+  exit 1
+fi
+
+case $draft_ids[1] in
+  (''|*[!0-9]*)
+    print -ru2 -- "resolved release ID is not numeric: $draft_ids[1]"
+    exit 1
+    ;;
+esac
+
+print -r -- "$draft_ids[1]"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,12 @@ set_tests_properties(release_workflow_policy PROPERTIES
   TIMEOUT 20
   LABELS "ci;release;security")
 
+add_test(NAME release_draft_resolution
+  COMMAND ${ZSH_EXECUTABLE} -f ${CMAKE_CURRENT_SOURCE_DIR}/ci/release_draft_resolution.zsh)
+set_tests_properties(release_draft_resolution PROPERTIES
+  TIMEOUT 20
+  LABELS "ci;release;security")
+
 add_test(NAME compatibility_policy
   COMMAND ${ZSH_EXECUTABLE} -f ${CMAKE_CURRENT_SOURCE_DIR}/ci/compatibility_policy.zsh)
 set_tests_properties(compatibility_policy PROPERTIES

--- a/tests/ci/release_draft_resolution.zsh
+++ b/tests/ci/release_draft_resolution.zsh
@@ -1,0 +1,105 @@
+#!/usr/bin/env zsh
+# Regression tests for resolving one exact private release draft.
+emulate -R zsh
+setopt err_exit no_unset pipe_fail
+
+repo_root=${0:A:h:h:h}
+resolver="$repo_root/scripts/resolve-release-draft.zsh"
+tmp_dir=$(mktemp -d)
+mock_bin="$tmp_dir/bin"
+stdout_file="$tmp_dir/stdout"
+stderr_file="$tmp_dir/stderr"
+
+cleanup() {
+  rm -rf -- "$tmp_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$mock_bin"
+cat > "$mock_bin/gh" <<'MOCK_GH'
+#!/usr/bin/env zsh
+emulate -R zsh
+setopt err_exit no_unset pipe_fail
+
+if (( ${MOCK_GH_STATUS:-0} != 0 )); then
+  print -ru2 -- 'mock GitHub API failure'
+  exit "$MOCK_GH_STATUS"
+fi
+
+if (( $# != 4 )) ||
+  [[ $1 != api || $2 != --paginate || $3 != --slurp ]] ||
+  [[ $4 != 'repos/z-shell/zpmod/releases?per_page=100' ]]; then
+  print -ru2 -- "unexpected gh invocation: $*"
+  exit 64
+fi
+print -r -- "$MOCK_RELEASES_JSON"
+MOCK_GH
+chmod +x "$mock_bin/gh"
+
+fail_test() {
+  print -ru2 -- "$*"
+  exit 1
+}
+
+run_resolver() {
+  PATH="$mock_bin:$PATH" zsh -f "$resolver" \
+    z-shell/zpmod v2.0.5 ea511d977800e3916776ad43d055afd4dcca734f \
+    > "$stdout_file" 2> "$stderr_file"
+}
+
+MOCK_RELEASES_JSON='[
+[
+  {"id": 11, "draft": false, "tag_name": "v2.0.5", "target_commitish": "ea511d977800e3916776ad43d055afd4dcca734f"},
+  {"id": 12, "draft": true, "tag_name": "v2.0.5", "target_commitish": "39b02adf471d1f40df0b985565dc16b97add1127"}
+],
+[
+  {"id": 377741043, "draft": true, "tag_name": "v2.0.5", "target_commitish": "ea511d977800e3916776ad43d055afd4dcca734f"}
+]
+]'
+export MOCK_RELEASES_JSON
+run_resolver || fail_test 'one exact draft did not resolve successfully'
+[[ $(< "$stdout_file") == 377741043 ]] ||
+  fail_test 'resolver did not return the exact numeric release ID'
+
+MOCK_RELEASES_JSON='[[
+  {"id": 11, "draft": false, "tag_name": "v2.0.5", "target_commitish": "ea511d977800e3916776ad43d055afd4dcca734f"},
+  {"id": 12, "draft": true, "tag_name": "v2.0.5", "target_commitish": "39b02adf471d1f40df0b985565dc16b97add1127"}
+]]'
+export MOCK_RELEASES_JSON
+if run_resolver; then
+  fail_test 'resolver accepted zero exact drafts'
+fi
+grep -q 'found 0' "$stderr_file" ||
+  fail_test 'zero-match failure did not report its cardinality'
+
+MOCK_RELEASES_JSON='[[
+  {"id": 21, "draft": true, "tag_name": "v2.0.5", "target_commitish": "ea511d977800e3916776ad43d055afd4dcca734f"},
+  {"id": 22, "draft": true, "tag_name": "v2.0.5", "target_commitish": "ea511d977800e3916776ad43d055afd4dcca734f"}
+]]'
+export MOCK_RELEASES_JSON
+if run_resolver; then
+  fail_test 'resolver accepted multiple exact drafts'
+fi
+grep -q 'found 2' "$stderr_file" ||
+  fail_test 'multiple-match failure did not report its cardinality'
+
+MOCK_RELEASES_JSON='[[
+  {"id": "not-numeric", "draft": true, "tag_name": "v2.0.5", "target_commitish": "ea511d977800e3916776ad43d055afd4dcca734f"}
+]]'
+export MOCK_RELEASES_JSON
+if run_resolver; then
+  fail_test 'resolver accepted a non-numeric release ID'
+fi
+grep -q 'not numeric' "$stderr_file" ||
+  fail_test 'non-numeric failure was not explicit'
+
+MOCK_RELEASES_JSON='[]'
+MOCK_GH_STATUS=73
+export MOCK_RELEASES_JSON MOCK_GH_STATUS
+if run_resolver; then
+  fail_test 'resolver hid a GitHub API failure'
+fi
+grep -q 'mock GitHub API failure' "$stderr_file" ||
+  fail_test 'GitHub API failure output was not preserved'
+
+print -r -- 'release_draft_resolution OK'

--- a/tests/ci/release_draft_resolution.zsh
+++ b/tests/ci/release_draft_resolution.zsh
@@ -36,6 +36,28 @@ print -r -- "$MOCK_RELEASES_JSON"
 MOCK_GH
 chmod +x "$mock_bin/gh"
 
+if ! command -v jq >/dev/null 2>&1; then
+  cat > "$mock_bin/jq" <<'MOCK_JQ'
+#!/usr/bin/env zsh
+emulate -R zsh
+setopt err_exit no_unset pipe_fail
+
+if (( $# != 8 )) ||
+  [[ $1 != -r || $2 != --arg || $3 != tag ]] ||
+  [[ $4 != v2.0.5 || $5 != --arg || $6 != commit ]] ||
+  [[ $7 != ea511d977800e3916776ad43d055afd4dcca734f ]] ||
+  [[ $8 != *'.draft == true'* ]] ||
+  [[ $8 != *'.tag_name == $tag'* ]] ||
+  [[ $8 != *'.target_commitish == $commit'* ]]; then
+  print -ru2 -- "unexpected jq invocation: $*"
+  exit 64
+fi
+
+print -r -- "${MOCK_JQ_OUTPUT-}"
+MOCK_JQ
+  chmod +x "$mock_bin/jq"
+fi
+
 fail_test() {
   print -ru2 -- "$*"
   exit 1
@@ -56,7 +78,8 @@ MOCK_RELEASES_JSON='[
   {"id": 377741043, "draft": true, "tag_name": "v2.0.5", "target_commitish": "ea511d977800e3916776ad43d055afd4dcca734f"}
 ]
 ]'
-export MOCK_RELEASES_JSON
+MOCK_JQ_OUTPUT=377741043
+export MOCK_RELEASES_JSON MOCK_JQ_OUTPUT
 run_resolver || fail_test 'one exact draft did not resolve successfully'
 [[ $(< "$stdout_file") == 377741043 ]] ||
   fail_test 'resolver did not return the exact numeric release ID'
@@ -65,7 +88,8 @@ MOCK_RELEASES_JSON='[[
   {"id": 11, "draft": false, "tag_name": "v2.0.5", "target_commitish": "ea511d977800e3916776ad43d055afd4dcca734f"},
   {"id": 12, "draft": true, "tag_name": "v2.0.5", "target_commitish": "39b02adf471d1f40df0b985565dc16b97add1127"}
 ]]'
-export MOCK_RELEASES_JSON
+MOCK_JQ_OUTPUT=
+export MOCK_RELEASES_JSON MOCK_JQ_OUTPUT
 if run_resolver; then
   fail_test 'resolver accepted zero exact drafts'
 fi
@@ -76,7 +100,8 @@ MOCK_RELEASES_JSON='[[
   {"id": 21, "draft": true, "tag_name": "v2.0.5", "target_commitish": "ea511d977800e3916776ad43d055afd4dcca734f"},
   {"id": 22, "draft": true, "tag_name": "v2.0.5", "target_commitish": "ea511d977800e3916776ad43d055afd4dcca734f"}
 ]]'
-export MOCK_RELEASES_JSON
+MOCK_JQ_OUTPUT=$'21\n22'
+export MOCK_RELEASES_JSON MOCK_JQ_OUTPUT
 if run_resolver; then
   fail_test 'resolver accepted multiple exact drafts'
 fi
@@ -86,7 +111,8 @@ grep -q 'found 2' "$stderr_file" ||
 MOCK_RELEASES_JSON='[[
   {"id": "not-numeric", "draft": true, "tag_name": "v2.0.5", "target_commitish": "ea511d977800e3916776ad43d055afd4dcca734f"}
 ]]'
-export MOCK_RELEASES_JSON
+MOCK_JQ_OUTPUT=not-numeric
+export MOCK_RELEASES_JSON MOCK_JQ_OUTPUT
 if run_resolver; then
   fail_test 'resolver accepted a non-numeric release ID'
 fi

--- a/tests/ci/release_workflow_policy.zsh
+++ b/tests/ci/release_workflow_policy.zsh
@@ -26,6 +26,7 @@ typeset -i job_has_apt_update=0
 typeset -i job_has_zsh=0
 typeset -i validator_invocations=0
 typeset -i qualified_main_refs=0
+typeset -i draft_resolver_invocations=0
 
 while IFS= read -r line || [[ -n $line ]]; do
   if [[ $line == jobs: ]]; then
@@ -70,12 +71,29 @@ grep -q -- '--verify-tag' "$release" ||
   fail_test 'release publication does not require the remote tag'
 grep -q -- '--draft' "$release" ||
   fail_test 'release assets are uploaded directly to a public release'
-grep -q 'gh release edit' "$release" ||
-  fail_test 'release workflow does not publish a validated draft'
+if grep -q 'releases/tags/\$RELEASE_TAG' "$release"; then
+  fail_test 'release workflow uses the published-only tag endpoint for drafts'
+fi
+draft_resolver_invocations=$(grep -c 'resolve-release-draft.zsh' "$release" || true)
+(( draft_resolver_invocations >= 2 )) ||
+  fail_test 'creation and cleanup do not both resolve the exact private draft'
+grep -q 'gh api -X PATCH' "$release" ||
+  fail_test 'release workflow does not publish by numeric release ID'
+grep -q 'draft=false' "$release" ||
+  fail_test 'release workflow does not publish the validated draft'
+if grep -q 'gh release edit.*RELEASE_TAG' "$release"; then
+  fail_test 'release workflow publishes by tag instead of numeric release ID'
+fi
 grep -q 'cleanup_draft' "$release" ||
   fail_test 'failed draft validation does not clean up the private release'
 grep -q 'draft_id=' "$release" ||
   fail_test 'draft cleanup is not scoped to a release ID'
+grep -q 'releases/\$draft_id' "$release" ||
+  fail_test 'draft validation is not bound to the numeric release ID'
+grep -q '\.target_commitish' "$release" ||
+  fail_test 'draft validation is not bound to the release commit'
+grep -q '\.tag_name' "$release" ||
+  fail_test 'draft validation is not bound to the release tag'
 if grep -q 'gh release delete.*RELEASE_TAG' "$release"; then
   fail_test 'draft cleanup can delete a pre-existing release by tag'
 fi


### PR DESCRIPTION
## Summary

- resolve private release drafts through the authenticated paginated release list
- require exactly one draft matching both the release tag and validated target commit
- bind draft validation, publication, and guarded cleanup to the numeric release ID
- add focused resolver and workflow-policy regressions

## Verification

- `cmake --build build-cmake --parallel 2`
- `ctest --test-dir build-cmake --output-on-failure` (53/53 passed)
- focused policy and resolver tests under system and staged Zsh
- Actionlint, Prettier 3.6.2, Yamllint 1.37.1, Zsh syntax and bytecode checks
- staged Gitleaks scan

Refs #96
