### PR TITLE
fix(release): tolerate delayed draft visibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,8 @@ jobs:
           RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
           RELEASE_COMMIT: ${{ needs.validate.outputs.release_commit }}
           RELEASE_TAG_OBJECT: ${{ needs.validate.outputs.release_tag_object }}
+          ZPMOD_RELEASE_DRAFT_MAX_ATTEMPTS: "6"
+          ZPMOD_RELEASE_DRAFT_DELAY_SECONDS: "2"
         run: |
           cat > "$RUNNER_TEMP/release-notes.md" <<EOF
           Cross-platform zsh module release built from commit \`$RELEASE_COMMIT\`.

--- a/scripts/resolve-release-draft.zsh
+++ b/scripts/resolve-release-draft.zsh
@@ -12,32 +12,61 @@ fi
 typeset repository=$1
 typeset release_tag=$2
 typeset release_commit=$3
+typeset max_attempts_raw=${ZPMOD_RELEASE_DRAFT_MAX_ATTEMPTS:-6}
+typeset delay_seconds_raw=${ZPMOD_RELEASE_DRAFT_DELAY_SECONDS:-2}
 typeset releases_json draft_ids_output
 typeset -a draft_ids
+typeset -i attempt max_attempts delay_seconds
 
-releases_json=$(gh api --paginate --slurp \
-  "repos/$repository/releases?per_page=100")
-draft_ids_output=$(jq -r \
-  --arg tag "$release_tag" \
-  --arg commit "$release_commit" \
-  '.[][] | select(
-    .draft == true and
-    .tag_name == $tag and
-    .target_commitish == $commit
-  ) | .id' <<< "$releases_json")
-draft_ids=( ${(f)draft_ids_output} )
-
-if (( ${#draft_ids[@]} != 1 )); then
+if [[ $max_attempts_raw != <-> ]] || (( 10#$max_attempts_raw < 1 )); then
   print -ru2 -- \
-    "expected exactly one draft for $release_tag at $release_commit; found ${#draft_ids[@]}"
-  exit 1
+    'ZPMOD_RELEASE_DRAFT_MAX_ATTEMPTS must be a positive integer'
+  exit 2
 fi
+if [[ $delay_seconds_raw != <-> ]]; then
+  print -ru2 -- \
+    'ZPMOD_RELEASE_DRAFT_DELAY_SECONDS must be a non-negative integer'
+  exit 2
+fi
+max_attempts=$(( 10#$max_attempts_raw ))
+delay_seconds=$(( 10#$delay_seconds_raw ))
 
-case $draft_ids[1] in
-  (''|*[!0-9]*)
-    print -ru2 -- "resolved release ID is not numeric: $draft_ids[1]"
+for (( attempt = 1; attempt <= max_attempts; ++attempt )); do
+  releases_json=$(gh api --paginate --slurp \
+    "repos/$repository/releases?per_page=100")
+  draft_ids_output=$(jq -r \
+    --arg tag "$release_tag" \
+    --arg commit "$release_commit" \
+    '.[][] | select(
+      .draft == true and
+      .tag_name == $tag and
+      .target_commitish == $commit
+    ) | .id' <<< "$releases_json")
+  draft_ids=( ${(f)draft_ids_output} )
+
+  if (( ${#draft_ids[@]} == 1 )); then
+    case $draft_ids[1] in
+      (''|*[!0-9]*)
+        print -ru2 -- "resolved release ID is not numeric: $draft_ids[1]"
+        exit 1
+        ;;
+    esac
+
+    print -r -- "$draft_ids[1]"
+    exit 0
+  fi
+
+  if (( ${#draft_ids[@]} > 1 )); then
+    print -ru2 -- \
+      "expected exactly one draft for $release_tag at $release_commit; found ${#draft_ids[@]}"
     exit 1
-    ;;
-esac
+  fi
 
-print -r -- "$draft_ids[1]"
+  if (( attempt < max_attempts )); then
+    sleep "$delay_seconds"
+  fi
+done
+
+print -ru2 -- \
+  "expected exactly one draft for $release_tag at $release_commit; found 0 after $max_attempts attempts"
+exit 1

--- a/tests/ci/release_draft_resolution.zsh
+++ b/tests/ci/release_draft_resolution.zsh
@@ -9,6 +9,8 @@ tmp_dir=$(mktemp -d)
 mock_bin="$tmp_dir/bin"
 stdout_file="$tmp_dir/stdout"
 stderr_file="$tmp_dir/stderr"
+gh_count_file="$tmp_dir/gh-count"
+sleep_count_file="$tmp_dir/sleep-count"
 
 cleanup() {
   rm -rf -- "$tmp_dir"
@@ -21,6 +23,13 @@ cat > "$mock_bin/gh" <<'MOCK_GH'
 emulate -R zsh
 setopt err_exit no_unset pipe_fail
 
+typeset -i invocation_count=0
+if [[ -s $MOCK_GH_COUNT_FILE ]]; then
+  invocation_count=$(< "$MOCK_GH_COUNT_FILE")
+fi
+(( ++invocation_count ))
+print -r -- "$invocation_count" >| "$MOCK_GH_COUNT_FILE"
+
 if (( ${MOCK_GH_STATUS:-0} != 0 )); then
   print -ru2 -- 'mock GitHub API failure'
   exit "$MOCK_GH_STATUS"
@@ -32,9 +41,32 @@ if (( $# != 4 )) ||
   print -ru2 -- "unexpected gh invocation: $*"
   exit 64
 fi
+if (( invocation_count <= ${MOCK_GH_ZERO_RESPONSES:-0} )); then
+  print -r -- '[[]]'
+  exit 0
+fi
 print -r -- "$MOCK_RELEASES_JSON"
 MOCK_GH
 chmod +x "$mock_bin/gh"
+
+cat > "$mock_bin/sleep" <<'MOCK_SLEEP'
+#!/usr/bin/env zsh
+emulate -R zsh
+setopt err_exit no_unset pipe_fail
+
+if (( $# != 1 )) || [[ $1 != "$MOCK_EXPECTED_SLEEP_SECONDS" ]]; then
+  print -ru2 -- "unexpected sleep invocation: $*"
+  exit 64
+fi
+
+typeset -i invocation_count=0
+if [[ -s $MOCK_SLEEP_COUNT_FILE ]]; then
+  invocation_count=$(< "$MOCK_SLEEP_COUNT_FILE")
+fi
+(( ++invocation_count ))
+print -r -- "$invocation_count" >| "$MOCK_SLEEP_COUNT_FILE"
+MOCK_SLEEP
+chmod +x "$mock_bin/sleep"
 
 if ! command -v jq >/dev/null 2>&1; then
   cat > "$mock_bin/jq" <<'MOCK_JQ'
@@ -53,6 +85,9 @@ if (( $# != 8 )) ||
   exit 64
 fi
 
+typeset releases_json
+releases_json=$(<&0)
+[[ $releases_json == '[[]]' ]] && exit 0
 print -r -- "${MOCK_JQ_OUTPUT-}"
 MOCK_JQ
   chmod +x "$mock_bin/jq"
@@ -61,6 +96,19 @@ fi
 fail_test() {
   print -ru2 -- "$*"
   exit 1
+}
+
+reset_mock_counts() {
+  : >| "$gh_count_file"
+  : >| "$sleep_count_file"
+}
+
+mock_count() {
+  if [[ -s $1 ]]; then
+    print -r -- "$(< "$1")"
+  else
+    print -r -- 0
+  fi
 }
 
 run_resolver() {
@@ -79,22 +127,54 @@ MOCK_RELEASES_JSON='[
 ]
 ]'
 MOCK_JQ_OUTPUT=377741043
-export MOCK_RELEASES_JSON MOCK_JQ_OUTPUT
+MOCK_GH_STATUS=0
+MOCK_GH_ZERO_RESPONSES=0
+MOCK_EXPECTED_SLEEP_SECONDS=0
+ZPMOD_RELEASE_DRAFT_MAX_ATTEMPTS=3
+ZPMOD_RELEASE_DRAFT_DELAY_SECONDS=0
+export MOCK_RELEASES_JSON MOCK_JQ_OUTPUT MOCK_GH_STATUS
+export MOCK_GH_ZERO_RESPONSES MOCK_GH_COUNT_FILE="$gh_count_file"
+export MOCK_EXPECTED_SLEEP_SECONDS MOCK_SLEEP_COUNT_FILE="$sleep_count_file"
+export ZPMOD_RELEASE_DRAFT_MAX_ATTEMPTS ZPMOD_RELEASE_DRAFT_DELAY_SECONDS
+reset_mock_counts
 run_resolver || fail_test 'one exact draft did not resolve successfully'
 [[ $(< "$stdout_file") == 377741043 ]] ||
   fail_test 'resolver did not return the exact numeric release ID'
+[[ $(mock_count "$gh_count_file") == 1 ]] ||
+  fail_test 'immediately visible draft was queried more than once'
+[[ $(mock_count "$sleep_count_file") == 0 ]] ||
+  fail_test 'immediately visible draft caused an unnecessary delay'
+
+MOCK_GH_ZERO_RESPONSES=2
+export MOCK_GH_ZERO_RESPONSES
+reset_mock_counts
+run_resolver || fail_test 'delayed exact draft did not resolve successfully'
+[[ $(< "$stdout_file") == 377741043 ]] ||
+  fail_test 'delayed resolver did not return the exact numeric release ID'
+[[ $(mock_count "$gh_count_file") == 3 ]] ||
+  fail_test 'delayed resolver did not stop at the first exact match'
+[[ $(mock_count "$sleep_count_file") == 2 ]] ||
+  fail_test 'delayed resolver did not pause only between zero-match attempts'
 
 MOCK_RELEASES_JSON='[[
   {"id": 11, "draft": false, "tag_name": "v2.0.5", "target_commitish": "ea511d977800e3916776ad43d055afd4dcca734f"},
   {"id": 12, "draft": true, "tag_name": "v2.0.5", "target_commitish": "39b02adf471d1f40df0b985565dc16b97add1127"}
 ]]'
 MOCK_JQ_OUTPUT=
-export MOCK_RELEASES_JSON MOCK_JQ_OUTPUT
+MOCK_GH_ZERO_RESPONSES=0
+export MOCK_RELEASES_JSON MOCK_JQ_OUTPUT MOCK_GH_ZERO_RESPONSES
+reset_mock_counts
 if run_resolver; then
   fail_test 'resolver accepted zero exact drafts'
 fi
 grep -q 'found 0' "$stderr_file" ||
   fail_test 'zero-match failure did not report its cardinality'
+grep -q 'after 3 attempts' "$stderr_file" ||
+  fail_test 'zero-match failure did not report the polling bound'
+[[ $(mock_count "$gh_count_file") == 3 ]] ||
+  fail_test 'zero-match resolver did not exhaust its bounded attempts'
+[[ $(mock_count "$sleep_count_file") == 2 ]] ||
+  fail_test 'zero-match resolver did not pause only between attempts'
 
 MOCK_RELEASES_JSON='[[
   {"id": 21, "draft": true, "tag_name": "v2.0.5", "target_commitish": "ea511d977800e3916776ad43d055afd4dcca734f"},
@@ -102,30 +182,69 @@ MOCK_RELEASES_JSON='[[
 ]]'
 MOCK_JQ_OUTPUT=$'21\n22'
 export MOCK_RELEASES_JSON MOCK_JQ_OUTPUT
+reset_mock_counts
 if run_resolver; then
   fail_test 'resolver accepted multiple exact drafts'
 fi
 grep -q 'found 2' "$stderr_file" ||
   fail_test 'multiple-match failure did not report its cardinality'
+[[ $(mock_count "$gh_count_file") == 1 ]] ||
+  fail_test 'multiple-match resolver retried an unsafe cardinality'
+[[ $(mock_count "$sleep_count_file") == 0 ]] ||
+  fail_test 'multiple-match resolver delayed before failing'
 
 MOCK_RELEASES_JSON='[[
   {"id": "not-numeric", "draft": true, "tag_name": "v2.0.5", "target_commitish": "ea511d977800e3916776ad43d055afd4dcca734f"}
 ]]'
 MOCK_JQ_OUTPUT=not-numeric
 export MOCK_RELEASES_JSON MOCK_JQ_OUTPUT
+reset_mock_counts
 if run_resolver; then
   fail_test 'resolver accepted a non-numeric release ID'
 fi
 grep -q 'not numeric' "$stderr_file" ||
   fail_test 'non-numeric failure was not explicit'
+[[ $(mock_count "$gh_count_file") == 1 ]] ||
+  fail_test 'resolver retried a non-numeric release ID'
+[[ $(mock_count "$sleep_count_file") == 0 ]] ||
+  fail_test 'resolver delayed after a non-numeric release ID'
 
 MOCK_RELEASES_JSON='[]'
 MOCK_GH_STATUS=73
 export MOCK_RELEASES_JSON MOCK_GH_STATUS
+reset_mock_counts
 if run_resolver; then
   fail_test 'resolver hid a GitHub API failure'
 fi
 grep -q 'mock GitHub API failure' "$stderr_file" ||
   fail_test 'GitHub API failure output was not preserved'
+[[ $(mock_count "$gh_count_file") == 1 ]] ||
+  fail_test 'resolver retried a GitHub API failure'
+[[ $(mock_count "$sleep_count_file") == 0 ]] ||
+  fail_test 'resolver delayed after a GitHub API failure'
+
+MOCK_GH_STATUS=0
+ZPMOD_RELEASE_DRAFT_MAX_ATTEMPTS=0
+export MOCK_GH_STATUS ZPMOD_RELEASE_DRAFT_MAX_ATTEMPTS
+reset_mock_counts
+if run_resolver; then
+  fail_test 'resolver accepted a zero attempt bound'
+fi
+grep -q 'must be a positive integer' "$stderr_file" ||
+  fail_test 'invalid attempt bound failure was not explicit'
+[[ $(mock_count "$gh_count_file") == 0 ]] ||
+  fail_test 'resolver queried GitHub with an invalid attempt bound'
+
+ZPMOD_RELEASE_DRAFT_MAX_ATTEMPTS=3
+ZPMOD_RELEASE_DRAFT_DELAY_SECONDS=invalid
+export ZPMOD_RELEASE_DRAFT_MAX_ATTEMPTS ZPMOD_RELEASE_DRAFT_DELAY_SECONDS
+reset_mock_counts
+if run_resolver; then
+  fail_test 'resolver accepted a non-numeric delay'
+fi
+grep -q 'must be a non-negative integer' "$stderr_file" ||
+  fail_test 'invalid retry delay failure was not explicit'
+[[ $(mock_count "$gh_count_file") == 0 ]] ||
+  fail_test 'resolver queried GitHub with an invalid retry delay'
 
 print -r -- 'release_draft_resolution OK'

--- a/tests/ci/release_workflow_policy.zsh
+++ b/tests/ci/release_workflow_policy.zsh
@@ -77,6 +77,10 @@ fi
 draft_resolver_invocations=$(grep -c 'resolve-release-draft.zsh' "$release" || true)
 (( draft_resolver_invocations >= 2 )) ||
   fail_test 'creation and cleanup do not both resolve the exact private draft'
+grep -q 'ZPMOD_RELEASE_DRAFT_MAX_ATTEMPTS: "6"' "$release" ||
+  fail_test 'release draft resolution lacks an explicit bounded attempt count'
+grep -q 'ZPMOD_RELEASE_DRAFT_DELAY_SECONDS: "2"' "$release" ||
+  fail_test 'release draft resolution lacks an explicit retry delay'
 grep -q 'gh api -X PATCH' "$release" ||
   fail_test 'release workflow does not publish by numeric release ID'
 grep -q 'draft=false' "$release" ||


### PR DESCRIPTION
## Summary

- Retry authenticated, paginated draft discovery only when the exact tag-and-target match count is zero.
- Bound publication and cleanup resolution to six attempts with two-second pauses, with no delay after the final attempt.
- Preserve immediate failure for API errors, multiple exact matches, nonnumeric release IDs, and invalid retry configuration.
- Add delayed-visibility, retry-bound, fail-fast, and workflow-policy regression coverage.

## Safety boundary

- Exact draft identity remains bound to the release tag and expected commit.
- Publication and guarded cleanup remain bound to the validated numeric release ID.
- Existing tags and release objects are not changed by this pull request.
- A release still requires separate maintainer authorization after merge and green merged-main checks.

## Verification

- Host Release build and CTest: 53/53 passed.
- Minimum-supported Zsh 5.8.1 container: 53/53 passed.
- Full-development Zsh 5.9 container: 53/53 passed.
- Focused draft-resolution and workflow-policy regressions: passed.
- Native Zsh syntax, `zcompile`, Actionlint, and diff checks: passed.

Refs #96.
