### PR TITLE
fix(paths): follow Zi XDG resolution

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -49,22 +49,24 @@ jobs:
           set -euo pipefail
           integration_root=$(mktemp -d "$RUNNER_TEMP/zpmod-zi.XXXXXX")
           zi_home="$integration_root/home"
+          zi_data="$integration_root/data"
           candidate_remote="$integration_root/zpmod-candidate.git"
-          mkdir -p "$zi_home/.zi/zmodules"
+          mkdir -p "$zi_home" "$zi_data/zi/zmodules"
 
           git clone --depth 1 https://github.com/z-shell/zi.git \
-            "$zi_home/.zi/bin"
-          zi_revision=$(git -C "$zi_home/.zi/bin" rev-parse HEAD)
+            "$zi_data/zi/bin"
+          zi_revision=$(git -C "$zi_data/zi/bin" rev-parse HEAD)
 
           git init --bare --quiet "$candidate_remote"
           git push --quiet "$candidate_remote" HEAD:refs/heads/ci-candidate
           git --git-dir="$candidate_remote" symbolic-ref \
             HEAD refs/heads/ci-candidate
           git clone --quiet "$candidate_remote" \
-            "$zi_home/.zi/zmodules/zpmod"
+            "$zi_data/zi/zmodules/zpmod"
 
           candidate_revision=$(git rev-parse HEAD)
           printf 'ZI_TEST_HOME=%s\n' "$zi_home" >> "$GITHUB_ENV"
+          printf 'ZI_TEST_DATA=%s\n' "$zi_data" >> "$GITHUB_ENV"
           printf 'ZI_REVISION=%s\n' "$zi_revision" >> "$GITHUB_ENV"
           printf 'ZPMOD_EXPECTED_REVISION=%s\n' \
             "$candidate_revision" >> "$GITHUB_ENV"
@@ -76,16 +78,17 @@ jobs:
         run: |
           HOME="$ZI_TEST_HOME" \
             ZDOTDIR="$ZI_TEST_HOME" \
+            XDG_DATA_HOME="$ZI_TEST_DATA" \
             XDG_CACHE_HOME="$ZI_TEST_HOME/.cache" \
             zsh -f -c '
-            source "$HOME/.zi/bin/zi.zsh" || exit 1
+            source "$XDG_DATA_HOME/zi/bin/zi.zsh" || exit 1
             zi module build --from-source
           '
 
       - name: Verify Zi-managed candidate
         run: |
           set -euo pipefail
-          module_root="$ZI_TEST_HOME/.zi/zmodules/zpmod"
+          module_root="$ZI_TEST_DATA/zi/zmodules/zpmod"
           actual_revision=$(git -C "$module_root" rev-parse HEAD)
           if [[ "$actual_revision" != "$ZPMOD_EXPECTED_REVISION" ]]; then
             printf 'Zi built revision %s instead of %s\n' \
@@ -95,6 +98,7 @@ jobs:
           test -s "$module_root/Src/zi/zpmod.so"
           HOME="$ZI_TEST_HOME" \
             ZDOTDIR="$ZI_TEST_HOME" \
+            XDG_DATA_HOME="$ZI_TEST_DATA" \
             XDG_CACHE_HOME="$ZI_TEST_HOME/.cache" \
             ZPMOD_MODULE_ROOT="$module_root" \
             zsh -f -c '

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ plugin manager does not compile plugins itself (and setups that don't use a plug
 ## Quick start
 
 ```zsh
-# Add to the top of ~/.zshrc
-module_path+=("${HOME}/.zi/zmodules/zpmod")
+# Use the RESOLVED_MODULE_DIR printed by the installer.
+module_path+=("/absolute/path/from/RESOLVED_MODULE_DIR")
 zmodload -i zpmod
 
 # After the shell starts, profile sourced scripts
@@ -23,6 +23,12 @@ zpmod source-study
 - Install with the CMake helper (`zi`, user, or system scope): see
   [docs/how-to/install-zpmod-with-cmake.md](docs/how-to/install-zpmod-with-cmake.md).
 - Install to a custom directory: see [docs/how-to/install-custom-dir.md](docs/how-to/install-custom-dir.md).
+
+`--install-zi` follows Zi's active path configuration. Without a loaded Zi, it
+retains a recognized legacy `$HOME/.zi` home and otherwise uses the absolute
+XDG data home or `$HOME/.local/share`. It never migrates data automatically.
+Because zpmod is a compiled module, rebuild it for each incompatible operating
+system, architecture, or Zsh version instead of sharing one binary install.
 
 ## Compatibility
 

--- a/docs/how-to/enable-debug.md
+++ b/docs/how-to/enable-debug.md
@@ -4,9 +4,12 @@ Set the environment variable before loading the module:
 
 ```zsh
 typeset -g ZI_MOD_DEBUG=1
-module_path+=("${HOME}/.zi/zmodules/zpmod")
+module_path+=("/absolute/path/from/RESOLVED_MODULE_DIR")
 zmodload zpmod
 ```
+
+Use the exact `RESOLVED_MODULE_DIR` printed by the installer in place of the
+placeholder.
 
 You will see warnings when compilation is skipped or when a file cannot be accessed.
 

--- a/docs/how-to/install-zpmod-with-cmake.md
+++ b/docs/how-to/install-zpmod-with-cmake.md
@@ -41,6 +41,13 @@ zmodload -i zpmod
 
 Tip: the script prints a ready-to-copy hint after installing; you can paste that into your `~/.zshrc`.
 
+For `--install-zi`, an active `ZI[ZMODULES_DIR]` wins. Without a loaded Zi, the
+helper retains a recognized legacy `$HOME/.zi` installation; otherwise it uses
+`${XDG_DATA_HOME}/zi` when the variable is absolute, or
+`$HOME/.local/share/zi` when it is unset, empty, or relative. It creates no
+parallel installation and performs no migration. Set `ZI[ZMODULES_DIR]`
+explicitly before running the helper to select a custom Zi destination.
+
 ## Build performance options
 
 You can control two optional performance toggles at configure time:
@@ -64,6 +71,9 @@ Notes:
 
 - LTO may increase link time but can improve runtime performance.
 - `-march=native` generates code optimized for your CPU and may not run on older/different machines.
+- A zpmod binary is also tied to its operating system, architecture, and Zsh
+  ABI. Do not reuse one shared Zi-data copy across incompatible environments;
+  rebuild it or use a machine-local explicit destination.
 
 ## Notes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,8 @@ Welcome to the zpmod documentation. This site follows the Divio documentation st
 ## Quick Start
 
 ```zsh
-# Add to top of ~/.zshrc
-module_path+=("${HOME}/.zi/zmodules/zpmod")
+# Paste the RESOLVED_MODULE_DIR printed by the installer.
+module_path+=("/absolute/path/from/RESOLVED_MODULE_DIR")
 zmodload -i zpmod
 
 # After shell start, profile sourced scripts

--- a/docs/tutorials/first-use.md
+++ b/docs/tutorials/first-use.md
@@ -29,9 +29,12 @@ Place the lines output by the installer at the very top of `~/.zshrc` (before pl
 `.` calls:
 
 ```zsh
-module_path+=("${HOME}/.zi/zmodules/zpmod")
+module_path+=("/absolute/path/from/RESOLVED_MODULE_DIR")
 zmodload -i zpmod
 ```
+
+Replace the placeholder with the exact `RESOLVED_MODULE_DIR` printed by the
+installer. This remains correct for explicit, legacy, and XDG Zi layouts.
 
 ## 3. Start a New Shell
 
@@ -62,6 +65,10 @@ You will see a list like:
 
 Pick a sourced script from the list, and look for a sibling `script.zwc`. If it exists and timestamps match or are newer, zpmod is
 successfully compiling.
+
+The installed module is architecture- and Zsh-ABI-sensitive. If your Zi data
+home is shared across different machines or Zsh builds, use a machine-local
+explicit destination or rebuild zpmod in each environment.
 
 ## 6. Enable Debug (Optional)
 

--- a/scripts/cmake.configure.zsh
+++ b/scripts/cmake.configure.zsh
@@ -363,36 +363,34 @@ function _print_artifact_hint() {
 
 if $INSTALL_ZI; then
   _msg "Installing for Zi (ZI[ZMODULES_DIR])"
-  # Resolve Zi modules root
-  zi_modules_root=
-  if typeset -p ZI >/dev/null 2>&1 && [[ ${+ZI} -eq 1 && -n ${ZI[ZMODULES_DIR]:-} ]]; then
-    zi_modules_root=${ZI[ZMODULES_DIR]}
-  elif [[ -n ${XDG_DATA_HOME:-} && -d ${XDG_DATA_HOME} ]]; then
-    zi_modules_root="$XDG_DATA_HOME/zi/zmodules"
-  else
-    zi_modules_root="$HOME/.zi/zmodules"
-  fi
+  builtin source "$REPO_ROOT/scripts/resolve-zi-paths.zsh" ||
+    _die "Could not load the Zi path resolver"
+  zpmod_resolve_zi_paths || _die "Could not resolve the Zi modules directory"
+  zi_modules_root=$REPLY
+  zi_home=$reply[1]
+  zi_layout=$reply[2]
+  compdir=$reply[3]
+  [[ $zi_layout == ambiguous-* ]] &&
+    _warn "Both legacy and XDG Zi homes were detected; using $zi_home. Set ZI[ZMODULES_DIR] explicitly to select another destination."
   zi_dest="$zi_modules_root/zpmod"
   _copy_so "$STAGED_SO" "$zi_dest" "Zi"
   print -r -- "To load: module_path+=( '$zi_dest' ); zmodload -i zpmod"
 
   # Optionally symlink completion into Zi's completions directory
-  if typeset -p ZI >/dev/null 2>&1 && [[ ${+ZI} -eq 1 && -n ${ZI[COMPLETIONS_DIR]:-} ]]; then
-    compdir=${ZI[COMPLETIONS_DIR]}
   src_comp="$REPO_ROOT/src/completion/_zpmod"
-    if [[ -f $src_comp ]]; then
-      mkdir -p -- "$compdir" || _warn "Cannot create completions dir: $compdir"
-      if [[ -e "$compdir/_zpmod" && ! -L "$compdir/_zpmod" ]]; then
-        _warn "Completion exists and is not a symlink: $compdir/_zpmod (skipping)"
-      else
-        ln -sfn -- "$src_comp" "$compdir/_zpmod" && _ok "Linked completion: $compdir/_zpmod" || _warn "Failed to link completion to $compdir"
-      fi
+  if [[ -f $src_comp ]]; then
+    mkdir -p -- "$compdir" || _warn "Cannot create completions dir: $compdir"
+    if [[ -e "$compdir/_zpmod" && ! -L "$compdir/_zpmod" ]]; then
+      _warn "Completion exists and is not a symlink: $compdir/_zpmod (skipping)"
     else
-      _warn "Completion source not found: $src_comp"
+      ln -sfn -- "$src_comp" "$compdir/_zpmod" &&
+        _ok "Linked completion: $compdir/_zpmod" ||
+        _warn "Failed to link completion to $compdir"
     fi
   else
-    _warn "ZI[COMPLETIONS_DIR] not set; skipping completion link"
+    _warn "Completion source not found: $src_comp"
   fi
+  unfunction zpmod_resolve_zi_paths
 fi
 
 if $INSTALL_USER; then

--- a/scripts/install.zsh
+++ b/scripts/install.zsh
@@ -146,6 +146,8 @@ parse_args() {
 done
 }
 parse_args "$@"
+typeset -g ZI_MODE_ACTIVE=0
+typeset -g ZI_MODULES_ROOT= ZI_HOME_DIR= ZI_COMPLETIONS_DIR= ZI_LAYOUT=
 
 # Basic zsh version advisory (not a hard error, but may help debugging older envs)
 if [[ -n ${ZSH_VERSION:-} ]]; then
@@ -164,6 +166,21 @@ if [[ -z $PREFIX ]]; then
     PREFIX=$HOME/.local
   elif (( INSTALL_SYSTEM )); then
     PREFIX=/usr/local
+  elif (( INSTALL_ZI )); then
+    builtin source "$REPO_ROOT/scripts/resolve-zi-paths.zsh" ||
+      _die "Could not load the Zi path resolver" $EXIT_ENV
+    zpmod_resolve_zi_paths ||
+      _die "Could not resolve the Zi modules directory" $EXIT_ENV
+    ZI_MODULES_ROOT=$REPLY
+    ZI_HOME_DIR=$reply[1]
+    ZI_LAYOUT=$reply[2]
+    ZI_COMPLETIONS_DIR=$reply[3]
+    ZI_MODE_ACTIVE=1
+    PREFIX=$ZI_HOME_DIR
+    unfunction zpmod_resolve_zi_paths
+    if [[ $ZI_LAYOUT == ambiguous-* ]]; then
+      _warn "Both legacy and XDG Zi homes were detected; using $ZI_HOME_DIR. Set ZI[ZMODULES_DIR] explicitly to select another destination."
+    fi
   elif [[ -n ${ZPMOD_PREFIX:-} ]]; then
     PREFIX=$ZPMOD_PREFIX
   else
@@ -194,8 +211,13 @@ if (( ! SKIP_COMPLETION )) && [[ ! -f $FUNC_SRC ]]; then
   SKIP_COMPLETION=1
 fi
 
-MOD_DEST_DIR=$DESTDIR$PREFIX/$MODULE_DIR_REL
-FUNC_DEST_DIR=$DESTDIR$PREFIX/share/zsh/site-functions
+if (( ZI_MODE_ACTIVE )); then
+  MOD_DEST_DIR=$DESTDIR$ZI_MODULES_ROOT/zpmod
+  FUNC_DEST_DIR=$DESTDIR$ZI_COMPLETIONS_DIR
+else
+  MOD_DEST_DIR=$DESTDIR$PREFIX/$MODULE_DIR_REL
+  FUNC_DEST_DIR=$DESTDIR$PREFIX/share/zsh/site-functions
+fi
 
 mkdir_p() {
   local d=$1
@@ -240,7 +262,7 @@ fi
 if (( DRY_RUN )); then
   _info "[dry-run] Installation summary"
 else
-  _info "Installed zpmod to $PREFIX ($MODULE_DIR_REL)"
+  _info "Installed zpmod to $MOD_DEST_DIR"
 fi
 
 if (( PRINT_PATHS )); then
@@ -249,7 +271,14 @@ if (( PRINT_PATHS )); then
 fi
 
 # Suggest user configuration if local prefix
-if (( ! QUIET )) && [[ $PREFIX == $HOME/.local ]]; then
+if (( ! QUIET && ZI_MODE_ACTIVE )); then
+  cat <<EOF
+Add to your ~/.zshrc if not already present:
+
+  module_path+=( "$MOD_DEST_DIR" )
+  zmodload -i zpmod
+EOF
+elif (( ! QUIET )) && [[ $PREFIX == $HOME/.local ]]; then
   cat <<EOF
 Add to your ~/.zshrc if not already present:
 
@@ -268,7 +297,7 @@ if (( VERIFY_LOAD )); then
     tmp_script=$(mktemp)
     cat > "$tmp_script" <<EOS
   emulate -LR zsh
-  module_path=( "$PREFIX/$MODULE_DIR_REL" $module_path )
+  module_path=( "$MOD_DEST_DIR" $module_path )
   zmodload -i zpmod || { print -u2 'Failed to load zpmod'; exit 1 }
   # Try calling a benign builtin (if any) or just print success
   print 'zpmod: load OK'

--- a/scripts/resolve-zi-paths.zsh
+++ b/scripts/resolve-zi-paths.zsh
@@ -1,0 +1,70 @@
+#!/usr/bin/env zsh
+# Resolve Zi-owned zpmod destinations without creating or moving anything.
+
+zpmod_resolve_zi_paths() {
+  builtin emulate -L zsh
+
+  local data_base legacy_home xdg_home selected_home layout marker
+  integer legacy_present=0 xdg_present=0
+
+  if typeset -p ZI >/dev/null 2>&1 &&
+    [[ ${+ZI} -eq 1 && -n ${ZI[ZMODULES_DIR]:-} ]]; then
+    REPLY=${ZI[ZMODULES_DIR]}
+    selected_home=${ZI[HOME_DIR]:-${REPLY:h}}
+    reply=(
+      "$selected_home"
+      active-zi
+      "${ZI[COMPLETIONS_DIR]:-${selected_home}/completions}"
+    )
+    return 0
+  fi
+
+  if [[ -n $XDG_DATA_HOME && $XDG_DATA_HOME == /* ]]; then
+    data_base=$XDG_DATA_HOME
+  else
+    data_base="${HOME}/.local/share"
+  fi
+  legacy_home="${HOME}/.zi"
+  xdg_home="${data_base}/zi"
+
+  if typeset -p ZI >/dev/null 2>&1 &&
+    [[ ${+ZI} -eq 1 && -n ${ZI[HOME_DIR]:-} ]]; then
+    selected_home=${ZI[HOME_DIR]}
+    layout=explicit
+  else
+    for marker in bin/zi.zsh plugins snippets completions zmodules; do
+      if [[ -e "${legacy_home}/${marker}" ]]; then
+        legacy_present=1
+        break
+      fi
+    done
+    for marker in bin/zi.zsh plugins snippets completions zmodules; do
+      if [[ -e "${xdg_home}/${marker}" ]]; then
+        xdg_present=1
+        break
+      fi
+    done
+
+    if (( legacy_present && xdg_present )); then
+      if { typeset -p ZI >/dev/null 2>&1 &&
+        [[ ${+ZI} -eq 1 &&
+          ( ${ZI[BIN_DIR]:-} == "${xdg_home}/bin" || ${ZI[BIN_DIR]:-} == "${xdg_home}/bin/"* ) ]] } ||
+        { [[ -e "${xdg_home}/bin/zi.zsh" && ! -e "${legacy_home}/bin/zi.zsh" ]] }; then
+        selected_home=$xdg_home
+        layout=ambiguous-xdg
+      else
+        selected_home=$legacy_home
+        layout=ambiguous-legacy
+      fi
+    elif (( legacy_present )); then
+      selected_home=$legacy_home
+      layout=legacy
+    else
+      selected_home=$xdg_home
+      layout=xdg
+    fi
+  fi
+
+  REPLY="${selected_home}/zmodules"
+  reply=( "$selected_home" "$layout" "${selected_home}/completions" )
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,12 @@ set_tests_properties(compatibility_policy PROPERTIES
   TIMEOUT 20
   LABELS "ci;compat;package")
 
+add_test(NAME zi_path_resolution
+  COMMAND ${ZSH_EXECUTABLE} -f ${CMAKE_CURRENT_SOURCE_DIR}/ci/zi_path_resolution.zsh)
+set_tests_properties(zi_path_resolution PROPERTIES
+  TIMEOUT 20
+  LABELS "ci;paths;install")
+
 add_test(NAME package_license_payload
   COMMAND ${ZSH_EXECUTABLE} -f ${CMAKE_CURRENT_SOURCE_DIR}/package/license_payload.zsh)
 set_tests_properties(package_license_payload PROPERTIES

--- a/tests/ci/zi_path_resolution.zsh
+++ b/tests/ci/zi_path_resolution.zsh
@@ -1,0 +1,110 @@
+#!/usr/bin/env zsh
+
+builtin emulate -LR zsh
+setopt errexit pipefail
+
+typeset source_root=${0:A:h:h:h}
+typeset temp_root
+temp_root=$(mktemp -d "${TMPDIR:-/tmp}/zpmod-zi-paths.XXXXXXXX")
+trap 'rm -rf -- "$temp_root"' EXIT INT TERM
+
+builtin source "$source_root/scripts/resolve-zi-paths.zsh"
+
+fail_test() {
+  print -ru2 -- "$*"
+  exit 1
+}
+
+assert_equal() {
+  [[ $1 == "$2" ]] || fail_test "$3: expected ${(qqq)2}, got ${(qqq)1}"
+}
+
+run_case() (
+  builtin emulate -LR zsh
+
+  local label=$1 root="$temp_root/$1" expected_modules expected_home expected_layout
+  command mkdir -p -- "$root/home"
+  typeset -gx HOME="$root/home"
+  unset XDG_DATA_HOME
+  typeset -gAH ZI
+  ZI=()
+
+  case $label in
+    active-zi)
+      ZI[HOME_DIR]="$root/active home"
+      ZI[ZMODULES_DIR]="$root/active modules"
+      ZI[COMPLETIONS_DIR]="$root/active completions"
+      expected_modules=${ZI[ZMODULES_DIR]}
+      expected_home=${ZI[HOME_DIR]}
+      expected_layout=active-zi
+      ;;
+    explicit-home)
+      ZI[HOME_DIR]="$root/explicit home"
+      expected_home=${ZI[HOME_DIR]}
+      expected_modules="$expected_home/zmodules"
+      expected_layout=explicit
+      ;;
+    xdg-missing-spaces)
+      typeset -gx XDG_DATA_HOME="$root/data root"
+      expected_home="$XDG_DATA_HOME/zi"
+      expected_modules="$expected_home/zmodules"
+      expected_layout=xdg
+      ;;
+    xdg-relative)
+      typeset -gx XDG_DATA_HOME='relative data'
+      expected_home="$HOME/.local/share/zi"
+      expected_modules="$expected_home/zmodules"
+      expected_layout=xdg
+      ;;
+    legacy-only)
+      command mkdir -p -- "$HOME/.zi/plugins"
+      expected_home="$HOME/.zi"
+      expected_modules="$expected_home/zmodules"
+      expected_layout=legacy
+      ;;
+    xdg-only)
+      typeset -gx XDG_DATA_HOME="$root/data"
+      command mkdir -p -- "$XDG_DATA_HOME/zi/plugins"
+      expected_home="$XDG_DATA_HOME/zi"
+      expected_modules="$expected_home/zmodules"
+      expected_layout=xdg
+      ;;
+    both-external)
+      typeset -gx XDG_DATA_HOME="$root/data"
+      command mkdir -p -- "$HOME/.zi/plugins" "$XDG_DATA_HOME/zi/plugins"
+      expected_home="$HOME/.zi"
+      expected_modules="$expected_home/zmodules"
+      expected_layout=ambiguous-legacy
+      ;;
+    both-xdg-source)
+      typeset -gx XDG_DATA_HOME="$root/data"
+      command mkdir -p -- "$HOME/.zi/plugins" "$XDG_DATA_HOME/zi/plugins"
+      ZI[BIN_DIR]="$XDG_DATA_HOME/zi/bin"
+      expected_home="$XDG_DATA_HOME/zi"
+      expected_modules="$expected_home/zmodules"
+      expected_layout=ambiguous-xdg
+      ;;
+    both-xdg-code)
+      typeset -gx XDG_DATA_HOME="$root/data"
+      command mkdir -p -- "$HOME/.zi/plugins" "$XDG_DATA_HOME/zi/bin" "$XDG_DATA_HOME/zi/plugins"
+      command touch "$XDG_DATA_HOME/zi/bin/zi.zsh"
+      expected_home="$XDG_DATA_HOME/zi"
+      expected_modules="$expected_home/zmodules"
+      expected_layout=ambiguous-xdg
+      ;;
+  esac
+
+  zpmod_resolve_zi_paths || fail_test "$label resolver failed"
+  assert_equal "$REPLY" "$expected_modules" "$label modules"
+  assert_equal "$reply[1]" "$expected_home" "$label home"
+  assert_equal "$reply[2]" "$expected_layout" "$label layout"
+  [[ ! -e $expected_modules ]] || [[ $label == legacy-only || $label == xdg-only || $label == both-* ]] ||
+    fail_test "$label created a destination"
+)
+
+typeset label
+for label in active-zi explicit-home xdg-missing-spaces xdg-relative legacy-only xdg-only both-external both-xdg-source both-xdg-code; do
+  run_case "$label"
+done
+
+print -r -- 'zi_path_resolution OK'


### PR DESCRIPTION
Closes #107.

Parent: https://github.com/z-shell/.github/issues/553
Project: https://github.com/orgs/z-shell/projects/28

## What this changes

- Adds one sourced resolver shared by both zpmod installer entry points.
- Gives active `ZI[ZMODULES_DIR]` highest precedence.
- Retains recognized legacy Zi homes and otherwise uses valid absolute XDG data paths or the specification fallback.
- Resolves both-present homes from Zi source identity and reports ambiguity without migrating data.
- Corrects `scripts/install.zsh --zi` module and completion destinations.
- Updates compatibility CI to exercise the XDG Zi layout.
- Replaces hard-coded legacy module paths in maintained documentation with the installer's resolved destination.
- Documents operating-system, architecture, and Zsh ABI sensitivity for compiled modules.

## Verification

- CMake configure and build pass.
- CTest passes 54/54 tests, including the new resolver matrix.
- Changed Zsh sources pass native syntax checks.
- The changed workflow passes actionlint.
- `git diff --check` passes.
